### PR TITLE
Fixing a problem with Alt + 3

### DIFF
--- a/editortools/clone.py
+++ b/editortools/clone.py
@@ -821,6 +821,9 @@ class CloneTool(EditorTool):
 
     def option2(self):
         self.copyWater = not self.copyWater
+        
+    def option3(self):
+        self.copyBiomes = not self.copyBiomes
 
     draggingFace = None
     draggingStartPoint = None


### PR DESCRIPTION
Copy Biomes supposed to work with Alt-3 (That's what it said in the description of that action) but it doesn't work so that should fix it
