### PR TITLE
Add individual block rotation

### DIFF
--- a/editortools/brush.py
+++ b/editortools/brush.py
@@ -1207,7 +1207,7 @@ class BrushTool(CloneTool):
     def toolEnabled(self):
         return True
 
-    def rotate(self):
+    def rotate(self,blocksOnly=False):
         offs = self.reticleOffset
         dist = self.editor.cameraToolDistance
         W, H, L = self.brushSize
@@ -1215,7 +1215,7 @@ class BrushTool(CloneTool):
         self.reticleOffset = offs
         self.editor.cameraToolDistance = dist
 
-    def mirror(self):
+    def mirror(self,blocksOnly=False):
         offs = self.reticleOffset
         dist = self.editor.cameraToolDistance
         W, H, L = self.brushSize
@@ -1229,10 +1229,10 @@ class BrushTool(CloneTool):
         else:
             self.panel.pickFillBlock()
 
-    def flip(self):
+    def flip(self,blocksOnly=False):
         self.decreaseBrushSize()
 
-    def roll(self):
+    def roll(self,blocksOnly=False):
         self.increaseBrushSize()
 
     def swap(self):

--- a/editortools/clone.py
+++ b/editortools/clone.py
@@ -800,40 +800,53 @@ class CloneTool(EditorTool):
         return self.level
 
     @alertException
-    def rotate(self, amount=1):
+    def rotate(self, amount=1, blocksOnly=False):
         if self.canRotateLevel:
             self.rotation += amount
             self.rotation &= 0x3
             for i in range(amount & 0x3):
-                self.level.rotateLeft()
+                if blocksOnly:
+                    self.level.rotateLeftBlocks()
+                else:
+                    self.level.rotateLeft()
 
             self.previewRenderer.level = self.level
 
     @alertException
-    def roll(self, amount=1):
+    def roll(self, amount=1, blocksOnly=False):
         if self.canRotateLevel:
             for i in range(amount & 0x3):
-                self.level.roll()
+                if blocksOnly:
+                    self.level.rollBlocks()
+                else:
+                    self.level.roll()
 
             self.previewRenderer.level = self.level
 
     @alertException
-    def flip(self, amount=1):
+    def flip(self, amount=1, blocksOnly=False):
         if self.canRotateLevel:
             for i in range(amount & 0x1):
-                self.level.flipVertical()
-
+                if blocksOnly:
+                    self.level.flipVertical()
+                else:
+                    self.level.flipVerticalBlocks()
             self.previewRenderer.level = self.level
 
     @alertException
-    def mirror(self):
+    def mirror(self, blocksOnly=False):
         if self.canRotateLevel:
             yaw = int(self.editor.mainViewport.yaw) % 360
             if (yaw >= 45 and yaw < 135) or (yaw > 225 and yaw <= 315):
-                self.level.flipEastWest()
+                if blocksOnly:
+                    self.level.flipEastWestBlocks()
+                else:
+                    self.level.flipEastWest()
             else:
-                self.level.flipNorthSouth()
-
+                if blocksOnly:
+                    self.level.flipNorthSouthBlocks()
+                else:
+                    self.level.flipNorthSouth()
             self.previewRenderer.level = self.level
 
     def option1(self):

--- a/editortools/editortool.py
+++ b/editortools/editortool.py
@@ -54,16 +54,16 @@ class EditorTool(object):
         self.previewRenderer.draw()
         GL.glDisable(GL.GL_POLYGON_OFFSET_FILL)
 
-    def rotate(self, amount=1):
+    def rotate(self, amount=1, blocksOnly=False):
         pass
 
-    def roll(self, amount=1):
+    def roll(self, amount=1, blocksOnly=False):
         pass
 
-    def flip(self, amount=1):
+    def flip(self, amount=1, blocksOnly=False):
         pass
 
-    def mirror(self, amount=1):
+    def mirror(self, amount=1, blocksOnly=False):
         pass
 
     def swap(self, amount=1):

--- a/editortools/fill.py
+++ b/editortools/fill.py
@@ -26,10 +26,10 @@ from glbackground import Panel
 from glutils import Texture
 from mceutils import showProgress, CheckBoxLabel, alertException, setWindowCaption
 from operation import Operation
+from pymclevel.blockrotation import Roll, RotateLeft, FlipVertical, FlipEastWest, FlipNorthSouth
 
 import config
 import pymclevel
-
 FillSettings = config.Settings("Fill")
 FillSettings.chooseBlockImmediately = FillSettings("Choose Block Immediately", True)
 
@@ -253,8 +253,39 @@ class FillTool(EditorTool):
         self.editor.invalidateBox(box)
         self.editor.toolbar.selectTool(-1)
 
-    def roll(self):
-        self.toggleReplacing()
+    def roll(self, amount=1, blocksOnly=False):
+        if blocksOnly:
+            id = [self._blockInfo.ID]
+            data = [self._blockInfo.blockData]
+            Roll(id,data)
+            self.blockInfo = self.editor.level.materials[(id[0], data[0])]
+        else:
+            self.toggleReplacing()
+
+    def mirror(self, amount=1, blocksOnly=False):
+        if blocksOnly:
+            id = [self._blockInfo.ID]
+            data = [self._blockInfo.blockData]
+            yaw = int(self.editor.mainViewport.yaw) % 360
+            if (yaw >= 45 and yaw < 135) or (yaw > 225 and yaw <= 315):
+                FlipEastWest(id,data)
+            else:
+                FlipNorthSouth(id,data)
+            self.blockInfo = self.editor.level.materials[(id[0], data[0])]
+
+    def flip(self, amount=1, blocksOnly=False):
+        if blocksOnly:
+            id = [self._blockInfo.ID]
+            data = [self._blockInfo.blockData]
+            FlipVertical(id,data)
+            self.blockInfo = self.editor.level.materials[(id[0], data[0])]
+
+    def rotate(self, amount=1, blocksOnly=False):
+        if blocksOnly:
+            id = [self._blockInfo.ID]
+            data = [self._blockInfo.blockData]
+            RotateLeft(id,data)
+            self.blockInfo = self.editor.level.materials[(id[0], data[0])]
 
     def toggleReplacing(self):
         self.replacing = not self.replacing

--- a/leveleditor.py
+++ b/leveleditor.py
@@ -2690,7 +2690,14 @@ class LevelEditor(GLViewport):
                 name = "option" + keyname
                 if hasattr(self.currentTool, name):
                     getattr(self.currentTool, name)()
-
+            if keyname == config.config.get('Keys', 'Flip'):
+                self.currentTool.flip(blocksOnly=True)
+            if keyname == config.config.get('Keys', 'Roll'):
+                self.currentTool.roll(blocksOnly=True)
+            if keyname == config.config.get('Keys', 'Rotate'):
+                self.currentTool.rotate(blocksOnly=True)
+            if keyname == config.config.get('Keys', 'Mirror'):
+                self.currentTool.mirror(blocksOnly=True)
         elif hasattr(evt, 'cmd') and evt.cmd:
             if keyname == config.config.get('Keys', 'Quit'):
                 self.quit()

--- a/pymclevel/schematic.py
+++ b/pymclevel/schematic.py
@@ -227,6 +227,11 @@ class MCSchematic(EntityLevel):
         root_tag["Length"] = nbt.TAG_Short(shape[1])
         root_tag["Width"] = nbt.TAG_Short(shape[0])
 
+    def rotateLeftBlocks(self):
+        """
+        rotateLeft the blocks direction without there location
+        """
+        blockrotation.RotateLeft(self.Blocks, self.Data)
 
     def rotateLeft(self):
         self._fakeEntities = None
@@ -278,6 +283,12 @@ class MCSchematic(EntityLevel):
                 tileTick["x"].value = newX
                 tileTick["z"].value = newZ
 
+    def rollBlocks(self):
+        """
+        rolls the blocks direction without the block location
+        """
+        blockrotation.Roll(self.Blocks, self.Data)
+
     def roll(self):
         " xxx rotate stuff - destroys biomes"
         self.root_tag.pop('Biomes', None)
@@ -324,6 +335,8 @@ class MCSchematic(EntityLevel):
                 newY = tileTick["x"].value
                 tileTick["x"].value = newX
                 tileTick["y"].value = newY
+    def flipVerticalBlocks(self):
+        blockrotation.FlipVertical(self.Blocks, self.Data)
 
     def flipVertical(self):
         " xxx delete stuff "
@@ -372,6 +385,8 @@ class MCSchematic(EntityLevel):
                    'Pointer': 4,
                    'Pigscene': 4,
                    'BurningSkull': 4}
+    def flipNorthSouthBlocks(self):
+        blockrotation.FlipNorthSouth(self.Blocks, self.Data)
 
     def flipNorthSouth(self):
         if "Biomes" in self.root_tag:
@@ -418,6 +433,9 @@ class MCSchematic(EntityLevel):
         if "TileTicks" in self.root_tag:
             for tileTick in self.TileTicks:
                 tileTick["x"].value = self.Width - tileTick["x"].value - 1
+
+    def flipEastWestBlocks(self):
+        blockrotation.FlipEastWest(self.Blocks, self.Data)
 
     def flipEastWest(self):
         if "Biomes" in self.root_tag:


### PR DESCRIPTION
Add the ability to rotate the blocks direction and not the location while using clone, schematic import and fill operations to bring into line with brush block rotations. As suggested by @TrazLander.  

To use press alt and the applicable roll/rotate/mirror/flip key.
