### PR TITLE
Ability to enlarge window

### DIFF
--- a/leveleditor.py
+++ b/leveleditor.py
@@ -1466,6 +1466,11 @@ class CameraViewport(GLViewport):
 
     _compass = None
 
+    def reloadTextures(self):
+        self._compass = None
+        self.skyList = None
+        self._ceilingList = None
+        self._floorQuadList = None
 
 class ChunkViewport(CameraViewport):
     defaultScale = 1.0  # pixels per block

--- a/mcedit.py
+++ b/mcedit.py
@@ -623,7 +623,14 @@ class MCEdit(GLViewport):
         """
         Handle window resizing events.
         """
+        # To resize reset the opengl context(pygame limitation)
+        # So reload display lists and textures
         self.displayContext._reset(self.size)
+        self.editor.renderer.discardAllChunks()
+        self.editor.toolbar.reloadTextures()
+        self.editor.mainViewport.reloadTextures()
+        self.editor.chunkViewport.reloadTextures()
+
         GLViewport.resized(self, dw, dh)
 
         (w, h) = self.size


### PR DESCRIPTION
Fix the inability to enlarge the window without forcing a restart, related issue #40. This solution is not ideal as the OpenGL context needs to be reloaded meaning it takes a small amount of time for the window to resize, but it seems like a limitation of PyGame.

Still TODO: Change the layout of some UI components to handle resizing 
