### PR TITLE
Fixed fill/replace block picker closing

### DIFF
--- a/editortools/blockpicker.py
+++ b/editortools/blockpicker.py
@@ -28,6 +28,7 @@ class BlockPicker(Dialog):
         Dialog.__init__(self, *a, **kw)
         panelWidth = 490
 
+        self.click_outside_response = 0
         self.materials = materials
         self.anySubtype = blockInfo.wildcard
 
@@ -65,7 +66,7 @@ class BlockPicker(Dialog):
                 r += " [{0}]".format(block.aka)
 
             return r
-        
+
         def formatBlockID(x):
             block = self.matchingBlocks[x]
             ident = "({id}:{data})".format (id=block.ID, data=block.blockData)
@@ -224,7 +225,7 @@ class BlockPicker(Dialog):
             self.selectedBlockIndex -= 1
             self.tableview.rows.scroll_to_item(self.selectedBlockIndex)
             self.blockButton.blockInfo = self.blockInfo
-            
+
         elif keyname == "DOWN" and self.selectedBlockIndex < len(self.matchingBlocks):
             self.selectedBlockIndex += 1
             self.tableview.rows.scroll_to_item(self.selectedBlockIndex)

--- a/editortools/fill.py
+++ b/editortools/fill.py
@@ -209,9 +209,6 @@ class FillTool(EditorTool):
                 self.blockInfo = blockPicker.blockInfo
                 self.showPanel()
 
-            else:
-                self.editor.toolbar.selectTool(-1)
-
     chooseBlockImmediately = FillSettings.chooseBlockImmediately.configProperty()
 
     def toolReselected(self):


### PR DESCRIPTION
When clicking outside the block picker window, it closes, you don't have to press ESC anymore. I wasn't able to  further process the click, so if you want to do anything else, for example select a different tool, you have to click twice.
