### PR TITLE
Fix replacing top slabs giving wrong/invalid data values

### DIFF
--- a/pymclevel/block_fill.py
+++ b/pymclevel/block_fill.py
@@ -32,18 +32,12 @@ def fillBlocksIter(level, box, blockInfo, blocksToReplace=()):
     else:
         chunkIterator = level.getChunkSlices(box)
 
-    # shouldRetainData = (not blockInfo.hasVariants and not any([b.hasVariants for b in blocksToReplace]))
-    # if shouldRetainData:
-    # log.info( "Preserving data bytes" )
-    shouldRetainData = False  # xxx old behavior overwrote blockdata with 0 when e.g. replacing water with lava
-
     log.info("Replacing {0} with {1}".format(blocksToReplace, blockInfo))
 
     changesLighting = True
     blocktable = None
     if len(blocksToReplace):
         blocktable = blockReplaceTable(blocksToReplace)
-        shouldRetainData = all([blockrotation.SameRotationType(blockInfo, b) for b in blocksToReplace])
 
         newAbsorption = level.materials.lightAbsorption[blockInfo.ID]
         oldAbsorptions = [level.materials.lightAbsorption[b.ID] for b in blocksToReplace]
@@ -83,8 +77,7 @@ def fillBlocksIter(level, box, blockInfo, blocksToReplace=()):
             # don't waste time relighting and copying if the mask is empty
             if blockCount:
                 blocks[:][mask] = blockInfo.ID
-                if not shouldRetainData:
-                    data[mask] = blockInfo.blockData
+                data[mask] = blockInfo.blockData
             else:
                 skipped += 1
                 needsLighting = False
@@ -98,8 +91,7 @@ def fillBlocksIter(level, box, blockInfo, blocksToReplace=()):
 
         else:
             blocks[:] = blockInfo.ID
-            if not shouldRetainData:
-                data[:] = blockInfo.blockData
+            data[:] = blockInfo.blockData
             chunk.removeTileEntitiesInBox(box)
 
         chunk.chunkChanged(needsLighting)


### PR DESCRIPTION
This issue was reported on [reddit](http://www.reddit.com/r/MCEdit/comments/2kxj7j/error_replace_tool_with_top_slab_not_working_right/). The fix was to remove retain data value logic from the fill blocks method which I think isn't very useful. If this functionality is wanted I think a better implementation is needed(something using block states) and an explicit option.  
