### PR TITLE
Update de_DE.trn

### DIFF
--- a/lang/de_DE.trn
+++ b/lang/de_DE.trn
@@ -581,7 +581,7 @@ t271 Finde:
 o272 Replace with:
 t272 Ersetzen mit:
 o273 When the fill tool is chosen, prompt for a block type.
-t273 Wenn das Füll Werkzeug ausgewählt ist, wählen Sie einen Blocktypen.
+t273 Wenn das Füll Werkzeug ausgewählt ist, nach dem Blocktyp fragen.
 o274 Filter
 t274 Filter
 o275 Strength
@@ -1494,7 +1494,7 @@ o695 Open the NBT Explorer to edit player's attributes and inventory
 t695 Öffne den NBT Explorer um die Attribute des Spielers und dessen Inventar zu editieren
 o696 Not yet implemented.
 Use the NBT Explorer to edit this player.
-t696  Noch nicht implementiert.
+t696 Noch nicht implementiert.
 Nutze den NBT Explorer um den Spieler zu editieren.
 o697 Error while getting player file.
 %s not found.
@@ -1791,12 +1791,12 @@ t829 Konnte die server.properties Datei nicht finden! Der FTP Client wird die We
 o830 Could not find the world folder from the server.properties file
 t830 Konnte den Welten Ordner von der server.properties Datei nicht finden
 o831 Choose Block Immediately for Replace
-t831 
+t831 Block für das Ersetzen sofort auswählen
 o832 Open Block Picker for Fill
-t832 
+t832 Öffne Blockauswahl für das Füllen
 o833 Open Block Picker for Replace
-t833 
+t833 Öffne Blockauswahl für das Ersetzen
 o834 When the replace tool is chosen, prompt for a block type.
-t834 
+t834 Wenn das Ersetz Tool ausgewählt ist, nach dem Blocktyp fragen.
 o835 Matching Coordinates
 t835 


### PR DESCRIPTION
Change 696 because it had one space too much.
Added translation for 831 - 834 (note that these translations may partwise be not so good)
835 is still missing because I don't know the context.

At the moment there are the translations "Tool" and "Werkzeug" for the English "tool". Maybe we should use only one, rather "Werkzeug".
Changed 273, I am using "fragen" here for "prompt". I know that is not the correct translation, but I hope/think it fits pretty well.