### PR TITLE
zh-CN update & missing strings

### DIFF
--- a/lang/cs_CZ.trn
+++ b/lang/cs_CZ.trn
@@ -1945,3 +1945,5 @@ o928 §f  White
 t928 
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
 t929 
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 

--- a/lang/de_DE.trn
+++ b/lang/de_DE.trn
@@ -1996,3 +1996,5 @@ o928 §f  White
 t928 
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
 t929 
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 

--- a/lang/fr_FR.trn
+++ b/lang/fr_FR.trn
@@ -1996,3 +1996,5 @@ o928 §f  White
 t928 §f  Blanc
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
 t929 Cliquez-glissez pour repositionner l'objet. Double-cliquez pour le prendre. Cliquez Importer ou appuyez sur Entrée pour confirmer.
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 

--- a/lang/ko_KR.trn
+++ b/lang/ko_KR.trn
@@ -1971,3 +1971,5 @@ o928 §f  White
 t928 
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
 t929 
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 

--- a/lang/nl_NL.trn
+++ b/lang/nl_NL.trn
@@ -1945,3 +1945,5 @@ o928 §f  White
 t928 
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
 t929 
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 

--- a/lang/template.trn
+++ b/lang/template.trn
@@ -1936,3 +1936,5 @@ o928 §f  White
 t928 
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
 t929 
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 

--- a/lang/zh_CN.trn
+++ b/lang/zh_CN.trn
@@ -1951,40 +1951,42 @@ t909 点击来设置出生点.
 o910 <Toolbar>
 t910 <工具栏>
 o911 Edit Sign
-t911 
+t911 编辑告示牌
 o912 Add Color Code...
-t912 
+t912 添加颜色代码...
 o913 §0  Black
-t913 
+t913 §0  黑色
 o914 §1  Dark Blue
-t914 
+t914 §1  深蓝色
 o915 §2  Dark Green
-t915 
+t915 §2  深绿色
 o916 §3  Dark Aqua
-t916 
+t916 §3  深青色
 o917 §4  Dark Red
-t917 
+t917 §4  深红色
 o918 §5  Dark Purple
-t918 
+t918 §5  深紫色
 o919 §6  Gold
-t919 
+t919 §6  金色
 o920 §7  Gray
-t920 
+t920 §7  灰色
 o921 §8  Dark Gray
-t921 
+t921 §8  深灰色
 o922 §9  Blue
-t922 
+t922 §9  蓝色
 o923 §a  Green
-t923 
+t923 §a  绿色
 o924 §b  Aqua
-t924 
+t924 §b  青色
 o925 §c  Red
-t925 
+t925 §c  红色
 o926 §d  Light Purple
-t926 
+t926 §d  淡紫色
 o927 §e  Yellow
-t927 
+t927 §e  黄色
 o928 §f  White
-t928 
+t928 §f  白色
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
-t929 
+t929 点击和拖动来重新放置物体. 双击将它拾起. 点击“导入”或按回车来确定.
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 为这个刷怪箱输入一个实体ID. 无效的ID可能使Minecraft崩溃. 按ESC取消.

--- a/lang/zh_TW.trn
+++ b/lang/zh_TW.trn
@@ -1971,3 +1971,5 @@ o928 §f  White
 t928 
 o929 Click and drag to reposition the item. Double-click to pick it up. Click Import or press Enter to confirm.
 t929 
+o930 Type in an EntityID for this spawner. Invalid IDs may crash Minecraft.
+t930 


### PR DESCRIPTION
Please add these strings below: (I don't know how to do it. The 2nd one seems not implemented?) They can be found in chest panel when you delete an item from world.
1. Deleting the item 'item name' from the entire world('number' chunks)
2. WARNING: You are about to modify the entire world. This cannot be undone. Really delete all copies of this item from all land, chests, furnaces, dispensers, dropped items, item-containing tiles, and player inventories in the world?