### PR TITLE
Added Waypoints

### DIFF
--- a/config.py
+++ b/config.py
@@ -519,7 +519,8 @@ definitions = {
         ("downloadPlayerSkins", "Download Player Skins", True),
         ("maxViewDistance", "Max View Distance", 32),
         ("drawPlayerHeads", "Draw Player Heads", True),
-        ("showCommands", "Show Commands when hovering", True)
+        ("showCommands", "Show Commands when hovering", True),
+        ("savePositionOnClose", "Save camera position on close", False)
     ],
     ("controls", "Controls"): [
         ("mouseSpeed", "mouse speed", 5.0),

--- a/leveleditor.py
+++ b/leveleditor.py
@@ -491,7 +491,10 @@ class LevelEditor(GLViewport):
         gotoWaypointButton = Button("Goto Waypoint", action=self.gotoWaypoint)
         deleteWaypointButton = Button("Delete Waypoint", action=self.deleteWaypoint)
         
-        col = Column((self.waypointsChoiceButton, Row((createWaypointButton, gotoWaypointButton, deleteWaypointButton)), Button("Close", action=self.waypointDialog.dismiss)))
+        saveCameraOnClose = CheckBoxLabel("Save Camera position on world close",
+                                    ref=config.settings.savePositionOnClose)
+        
+        col = Column((self.waypointsChoiceButton, Row((createWaypointButton, gotoWaypointButton, deleteWaypointButton)), saveCameraOnClose, Button("Close", action=self.waypointDialog.dismiss)))
         self.waypointDialog.add(col)
         self.waypointDialog.shrink_wrap()
         #qd.topleft = self.waypointsButton.bottomleft
@@ -2099,6 +2102,8 @@ class LevelEditor(GLViewport):
         for p in self.toolbar.tools[6].nonSavedPlayers:
             if os.path.exists(p):
                 os.remove(p)
+        if config.settings.savePositionOnClose.get():
+            self.saveLastPosition()
         self.clearUnsavedEdits()
         self.unsavedEdits = 0
         self.root.RemoveEditFiles()


### PR DESCRIPTION
* Allows for user defined "waypoints" that snap the camera to a specified position
  * These waypoints can also save camera rotation
  * Waypoints also store and switch to different dimensions
* When the session.lock is lost, the current camera position and rotation is saved
  * When either reloading the world, or reopening MCEdit, the last position/rotation is saved
* The user can also toggle for the last camera position to be saved when the world is closed
* The waypoints are stored in a "mcedit_waypoints.dat" file in the world save folder