### PR TITLE
Missing Strings & zh-CN Update 

### DIFF
--- a/lang/cs_CZ.trn
+++ b/lang/cs_CZ.trn
@@ -1971,3 +1971,7 @@ o941 Delete Waypoint
 t941 
 o942 Save Camera position on world close
 t942 
+o943 Save Rotation
+t943 
+o945 Waypoint Name:
+t945 

--- a/lang/de_DE.trn
+++ b/lang/de_DE.trn
@@ -2021,3 +2021,7 @@ o941 Delete Waypoint
 t941 Wegpunkt löschen
 o942 Save Camera position on world close
 t942 Kameraposition beim Schließen der Welt speichern
+o943 Save Rotation
+t943 
+o945 Waypoint Name:
+t945 

--- a/lang/fr_FR.trn
+++ b/lang/fr_FR.trn
@@ -2022,3 +2022,7 @@ o941 Delete Waypoint
 t941 Suppr. point
 o942 Save Camera position on world close
 t942 Sauver la position de la caméra en quitant
+o943 Save Rotation
+t943 
+o945 Waypoint Name:
+t945 

--- a/lang/ko_KR.trn
+++ b/lang/ko_KR.trn
@@ -1997,3 +1997,7 @@ o941 Delete Waypoint
 t941 웨이포인트 삭제
 o942 Save Camera position on world close
 t942 맵 종료시 카메라 위치를 저장
+o943 Save Rotation
+t943 
+o945 Waypoint Name:
+t945 

--- a/lang/nl_NL.trn
+++ b/lang/nl_NL.trn
@@ -1971,3 +1971,7 @@ o941 Delete Waypoint
 t941 
 o942 Save Camera position on world close
 t942 
+o943 Save Rotation
+t943 
+o945 Waypoint Name:
+t945 

--- a/lang/template.trn
+++ b/lang/template.trn
@@ -1962,3 +1962,7 @@ o941 Delete Waypoint
 t941 
 o942 Save Camera position on world close
 t942 
+o943 Save Rotation
+t943 
+o945 Waypoint Name:
+t945 

--- a/lang/zh_CN.trn
+++ b/lang/zh_CN.trn
@@ -2007,16 +2007,20 @@ t934 使用下方的选项来指定要显示/隐藏的矿石
 o935 NBTEdit
 t935 NBT编辑器
 o936 Save camera position on close
-t936 
+t936 在关闭世界时保存镜头所在位置
 o937 Waypoints
-t937 
+t937 路径点
 o938 Empty
-t938 
+t938 空
 o939 Create Waypoint
-t939 
+t939 新建路径点
 o940 Goto Waypoint
-t940 
+t940 转到路径点
 o941 Delete Waypoint
-t941 
+t941 删除路径点
 o942 Save Camera position on world close
-t942 
+t942 在关闭世界时保存镜头所在位置
+o943 Save Rotation
+t943 保存镜头朝向
+o945 Waypoint Name:
+t945 路径点名字：

--- a/lang/zh_TW.trn
+++ b/lang/zh_TW.trn
@@ -1997,3 +1997,7 @@ o941 Delete Waypoint
 t941 
 o942 Save Camera position on world close
 t942 
+o943 Save Rotation
+t943 
+o945 Waypoint Name:
+t945 


### PR DESCRIPTION
Add 2 missing strings for Waypoint

Note that "Empty" is not translated in the software presumably because it automatically adds "(0.0, 0.0, 0.0)" at the back of "Empty" when you create a waypoint for the first time. It actually goes like "Empty (0.0,0.0,0.0)"
@LaChal @Podshot 