### PR TITLE
Data directory changes

### DIFF
--- a/albow/file_dialogs.py
+++ b/albow/file_dialogs.py
@@ -24,18 +24,21 @@ from albow.scrollpanel import ScrollPanel
 from albow.theme import ThemeProperty
 from translate import _
 from tree import Tree
-from directories import getDataDir
-
 import logging
 log = logging.getLogger(__name__)
 
-if sys.platform in ('darwin', 'linux2'):
+
+DEBUG = False
+
+if DEBUG:
+    from albow.resource import get_image
+
     print "*** MCEDIT DEBUG: file_dialog:", __file__
     print "*** MCEDIT DEBUG: directory:", os.path.dirname(__file__)
     print "*** MCEDIT DEBUG: current directory:", os.getcwd()
     try:
-        file_image = image.load('file.png')
-        folder_image = image.load('folder.png')
+        file_image = get_image('file.png')
+        folder_image = get_image('folder.png')
     except Exception, e:
         print "MCEDIT DEBUG: Could not load file dialog images."
         print e
@@ -51,9 +54,35 @@ if sys.platform in ('darwin', 'linux2'):
         draw.line(folder_image, (255, 255, 255, 255), [3, 15], [3, 1], 2)
         draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 0, pi/1.9, 2)
         draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 3*pi/2, 2*pi, 2)
-else: # windows
-    file_image = image.load(os.path.join(getDataDir(), 'file.png'))
-    folder_image = image.load(os.path.join(getDataDir(), 'folder.png'))
+
+else:
+    from directories import getDataDir
+
+    if sys.platform in ('darwin', 'linux2'):
+        print "*** MCEDIT DEBUG: file_dialog:", __file__
+        print "*** MCEDIT DEBUG: directory:", os.path.dirname(__file__)
+        print "*** MCEDIT DEBUG: current directory:", os.getcwd()
+        try:
+            file_image = image.load('file.png')
+            folder_image = image.load('folder.png')
+        except Exception, e:
+            print "MCEDIT DEBUG: Could not load file dialog images."
+            print e
+            from pygame import draw, Surface
+            from pygame.locals import SRCALPHA
+            from math import pi
+            file_image = Surface((16, 16), SRCALPHA)
+            file_image.fill((0,0,0,0))
+            draw.lines(file_image, (255, 255, 255, 255), False, [[3, 15], [3, 1], [13, 1]], 2)
+            draw.line(file_image, (255, 255, 255, 255), [3, 7], [10, 7], 2)
+            folder_image = Surface((16, 16), SRCALPHA)
+            folder_image.fill((0,0,0,0))
+            draw.line(folder_image, (255, 255, 255, 255), [3, 15], [3, 1], 2)
+            draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 0, pi/1.9, 2)
+            draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 3*pi/2, 2*pi, 2)
+    else: # windows
+        file_image = image.load(os.path.join(getDataDir(), 'file.png'))
+        folder_image = image.load(os.path.join(getDataDir(), 'folder.png'))
 
 class DirPathView(Widget):
     def __init__(self, width, client, **kwds):

--- a/albow/file_dialogs.py
+++ b/albow/file_dialogs.py
@@ -28,32 +28,35 @@ import logging
 log = logging.getLogger(__name__)
 
 
-DEBUG = False
+DEBUG = True
 
 if DEBUG:
     from albow.resource import get_image
 
-    print "*** MCEDIT DEBUG: file_dialog:", __file__
-    print "*** MCEDIT DEBUG: directory:", os.path.dirname(__file__)
-    print "*** MCEDIT DEBUG: current directory:", os.getcwd()
-    try:
-        file_image = get_image('file.png')
-        folder_image = get_image('folder.png')
-    except Exception, e:
-        print "MCEDIT DEBUG: Could not load file dialog images."
-        print e
-        from pygame import draw, Surface
-        from pygame.locals import SRCALPHA
-        from math import pi
-        file_image = Surface((16, 16), SRCALPHA)
-        file_image.fill((0,0,0,0))
-        draw.lines(file_image, (255, 255, 255, 255), False, [[3, 15], [3, 1], [13, 1]], 2)
-        draw.line(file_image, (255, 255, 255, 255), [3, 7], [10, 7], 2)
-        folder_image = Surface((16, 16), SRCALPHA)
-        folder_image.fill((0,0,0,0))
-        draw.line(folder_image, (255, 255, 255, 255), [3, 15], [3, 1], 2)
-        draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 0, pi/1.9, 2)
-        draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 3*pi/2, 2*pi, 2)
+    def get_imgs():
+        """Load an return the images used as file and folder icons."""
+        print "*** MCEDIT DEBUG: file_dialog:", __file__
+        print "*** MCEDIT DEBUG: directory:", os.path.dirname(__file__)
+        print "*** MCEDIT DEBUG: current directory:", os.getcwd()
+        try:
+            file_image = get_image('file.png', prefix='')
+            folder_image = get_image('folder.png', prefix='')
+        except Exception, e:
+            print "MCEDIT DEBUG: Could not load file dialog images."
+            print e
+            from pygame import draw, Surface
+            from pygame.locals import SRCALPHA
+            from math import pi
+            file_image = Surface((16, 16), SRCALPHA)
+            file_image.fill((0,0,0,0))
+            draw.lines(file_image, (255, 255, 255, 255), False, [[3, 15], [3, 1], [13, 1]], 2)
+            draw.line(file_image, (255, 255, 255, 255), [3, 7], [10, 7], 2)
+            folder_image = Surface((16, 16), SRCALPHA)
+            folder_image.fill((0,0,0,0))
+            draw.line(folder_image, (255, 255, 255, 255), [3, 15], [3, 1], 2)
+            draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 0, pi/1.9, 2)
+            draw.arc(folder_image, (255, 255, 255, 255), [0, 1, 13, 15], 3*pi/2, 2*pi, 2)
+        return file_image, folder_image
 
 else:
     from directories import getDataDir
@@ -110,6 +113,10 @@ class FileListView(ScrollPanel):
         d = 2 * self.predict(kwds, 'margin')
         kwds['align'] = kwds.get('align', 'l')
         ScrollPanel.__init__(self, inner_width=width, **kwds)
+
+        if DEBUG:
+            file_image, folder_image = get_imgs()
+
         self.icons = {True: scale(folder_image, (self.row_height, self.row_height)), False: scale(file_image, (self.row_height, self.row_height))}
         self.client = client
         self.names = []

--- a/mcplatform.py
+++ b/mcplatform.py
@@ -71,8 +71,8 @@ schematicsDir = directories.schematicsDir
 
 #!# Disabling platform specific file chooser:
 #!# Please, don't touch these two lines and the 'platChooser' stuff. -- D.C.-G.
-platChooser = sys.platform in ('linux2', 'darwin')
-# platChooser = sys.platform == 'darwin'
+# platChooser = sys.platform in ('linux2', 'darwin')
+platChooser = sys.platform == 'darwin'
 
 def getTexturePacks():
     try:

--- a/mcplatform.py
+++ b/mcplatform.py
@@ -71,8 +71,8 @@ schematicsDir = directories.schematicsDir
 
 #!# Disabling platform specific file chooser:
 #!# Please, don't touch these two lines and the 'platChooser' stuff. -- D.C.-G.
-# platChooser = sys.platform in ('linux2', 'darwin')
-platChooser = sys.platform == 'darwin'
+platChooser = sys.platform in ('linux2', 'darwin')
+# platChooser = sys.platform == 'darwin'
 
 def getTexturePacks():
     try:


### PR DESCRIPTION
Images used as icons in the internal file chooser are now loaded when the file chooser is called the firstime; no more at startup. (Avoids bugs due to differnces between source and compiled forms on OSX.)