### PR TITLE
Prevent history entry on platform unhide

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
 					$('#Win-downloads-toplevel').removeClass('col-md-offset-4');
 				}
 				$('.override-platform-specific-downloads-container').hide();
+				return false;
 			});
 
 			var releaseData = getReleaseData();


### PR DESCRIPTION
Returning false from an onclick action prevents the default action from triggering, in this case navigating to the # href (adding a new blank history entry).

Try it on http://khroki.github.io/MCEdit-Unified/ and "★ Click here to view other platforms"