### PR TITLE
Temporary adding pocket blocks

### DIFF
--- a/pymclevel/pocket.yaml
+++ b/pymclevel/pocket.yaml
@@ -1214,6 +1214,48 @@ blocks:
           TOP: [16, 3]
           BOTTOM: [16, 3]
     opacity: 0
+    
+  - id: 55
+    idStr: redstone_wire
+    name: Redstone Dust
+    search: wire
+    mapcolor: [245, 50, 50]
+    tex: [31, 31]
+    type: FLOOR
+    opacity: 0
+    data:
+      0:
+        name: Redstone Dust (Power 0)
+      1:
+        name: Redstone Dust (Power 1)
+      2:
+        name: Redstone Dust (Power 2)
+      3:
+        name: Redstone Dust (Power 3)
+      4:
+        name: Redstone Dust (Power 4)
+      5:
+        name: Redstone Dust (Power 5)
+      6:
+        name: Redstone Dust (Power 6)
+      7:
+        name: Redstone Dust (Power 7)
+      8:
+        name: Redstone Dust (Power 8)
+      9:
+        name: Redstone Dust (Power 9)
+      10:
+        name: Redstone Dust (Power 10)
+      11:
+        name: Redstone Dust (Power 11)
+      12:
+        name: Redstone Dust (Power 12)
+      13:
+        name: Redstone Dust (Power 13)
+      14:
+        name: Redstone Dust (Power 14)
+      15:
+        name: Redstone Dust (Power 15)
 
   - id: 56
     idStr: diamond_ore


### PR DESCRIPTION
Just copied block IDs from minecraft.yaml
They might not be the same in MCPE
There must be many missing blocks but I don't have time and will to do it right now.
All added blocks have set tex [31, 31] so that it is easier to find and change them later.

-----To do list, not accurate-----(according to http://minecraftpocketedition.wikia.com/wiki/Category:Blocks)
Observer
Piston
Command Block
Hopper
Redstone Comparator
Cauldron
Redstone Repeater
Daylight Sensor
Note Block
Stained Glass
Trapped Chest
Redstone Lamp
Weighted Pressure Plate
Slime Blocks
Mob Head
Levers
Flower Pot
Pressure Plate
Grass Path
Ender Chest
Soul Sand
Emerald Ore
Item Frame
Monster Egg
Wooden Door Variation
Iron Trapdoor
Nether Brick Slab
(don't know block IDs of these blocks)