### PR TITLE
glWindoPos2 fix

### DIFF
--- a/utilities/gl_display_context.py
+++ b/utilities/gl_display_context.py
@@ -31,7 +31,7 @@ class GLDisplayContext(object):
 
     @staticmethod
     def displayMode():
-        return pygame.OPENGL | pygame.RESIZABLE | pygame.DOUBLEBUF
+        return pygame.OPENGL | pygame.RESIZABLE | pygame.DOUBLEBUF | pygame.OPENGLBLIT
 
     def reset(self, splash=None, caption=("", "")):
         pygame.key.set_repeat(500, 100)
@@ -50,10 +50,11 @@ class GLDisplayContext(object):
             print "wwh 1", wwh
         d = display.set_mode(wwh, self.displayMode())
 
+        # Let initialize OpenGL stuff after the splash.
         GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
         GL.glAlphaFunc(GL.GL_NOTEQUAL, 0)
         GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
-
+ 
         # textures are 256x256, so with this we can specify pixel coordinates
         GL.glMatrixMode(GL.GL_TEXTURE)
         GL.glScale(1 / 256., 1 / 256., 1 / 256.)
@@ -101,8 +102,10 @@ class GLDisplayContext(object):
                 print "wwh 2", wwh
 
         if splash:
-            GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
-            GL.glWindowPos2d(0, 0)
+            # Let initialize OpenGL stuff after the splash.
+#             GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+            #!# The next line can be removed (Linux, from source).
+            # GL.glWindowPos2d(0, 0)
             back = Surface(wwh)
             back.fill((0, 0, 0))
             GL.glDrawPixels(wwh[0], wwh[1], GL.GL_RGBA, GL.GL_UNSIGNED_BYTE,
@@ -114,6 +117,7 @@ class GLDisplayContext(object):
             GL.glWindowPos2d(_x, _y)
             GL.glDrawPixels(w, h,
                             GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, numpy.fromstring(data, dtype='uint8'))
+#             d.blit(splash, (0, 0))
 
         if splash:
             display.flip()
@@ -126,6 +130,18 @@ class GLDisplayContext(object):
             self.win.set_position((x, y), update=True)
             if DEBUG_WM:
                 print "* self.win.get_position()", self.win.get_position()
+
+        # Initialize OpenGL stuff now.
+#         GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
+#         GL.glAlphaFunc(GL.GL_NOTEQUAL, 0)
+#         GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+# 
+#         # textures are 256x256, so with this we can specify pixel coordinates
+#         GL.glMatrixMode(GL.GL_TEXTURE)
+#         GL.glScale(1 / 256., 1 / 256., 1 / 256.)
+#         
+#         GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+
 
         try:
             iconpath = os.path.join(directories.getDataDir(), 'favicon.png')
@@ -185,3 +201,4 @@ class GLDisplayContext(object):
                     functools.partial(makeTerrainTexture, mats)
                 )
             mats.terrainTexture = self.terrainTextures[mats.name]
+

--- a/utilities/gl_display_context.py
+++ b/utilities/gl_display_context.py
@@ -102,14 +102,11 @@ class GLDisplayContext(object):
                 print "wwh 2", wwh
 
         if splash:
-            back = Surface(wwh)
-            back.fill((0, 0, 0))
-
             # Setup the OGL display
             GL.glLoadIdentity()
             GLU.gluOrtho2D(0, wwh[0], 0, wwh[1])
-            GL.glDrawPixels(wwh[0], wwh[1], GL.GL_RGBA, GL.GL_UNSIGNED_BYTE,
-                            numpy.fromstring(image.tostring(back, 'RGBA'), dtype='uint8'))
+            GL.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT | GL.GL_ACCUM_BUFFER_BIT | GL.GL_STENCIL_BUFFER_BIT)
+
             swh = splash.get_size()
             _x, _y = (wwh[0] / 2 - swh[0] / 2, wwh[1] / 2 - swh[1] / 2)
             w, h = swh

--- a/utilities/gl_display_context.py
+++ b/utilities/gl_display_context.py
@@ -1,4 +1,4 @@
-from OpenGL import GL
+from OpenGL import GL, GLU
 from config import config
 import pygame
 from pygame import display, image, Surface
@@ -51,13 +51,13 @@ class GLDisplayContext(object):
         d = display.set_mode(wwh, self.displayMode())
 
         # Let initialize OpenGL stuff after the splash.
-        GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
-        GL.glAlphaFunc(GL.GL_NOTEQUAL, 0)
-        GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+#        GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
+#        GL.glAlphaFunc(GL.GL_NOTEQUAL, 0)
+#        GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
  
         # textures are 256x256, so with this we can specify pixel coordinates
-        GL.glMatrixMode(GL.GL_TEXTURE)
-        GL.glScale(1 / 256., 1 / 256., 1 / 256.)
+#        GL.glMatrixMode(GL.GL_TEXTURE)
+#        GL.glScale(1 / 256., 1 / 256., 1 / 256.)
 
         display.set_caption(*caption)
 
@@ -104,13 +104,20 @@ class GLDisplayContext(object):
         if splash:
             back = Surface(wwh)
             back.fill((0, 0, 0))
+
+            # Setup the OGL display
+            GL.glLoadIdentity()
+            GLU.gluOrtho2D(0, wwh[0], 0, wwh[1])
             GL.glDrawPixels(wwh[0], wwh[1], GL.GL_RGBA, GL.GL_UNSIGNED_BYTE,
                             numpy.fromstring(image.tostring(back, 'RGBA'), dtype='uint8'))
             swh = splash.get_size()
             _x, _y = (wwh[0] / 2 - swh[0] / 2, wwh[1] / 2 - swh[1] / 2)
             w, h = swh
             data = image.tostring(splash, 'RGBA', 1)
-            GL.glWindowPos3d(_x, _y, 0)
+
+            # Set the raster position
+            GL.glRasterPos(_x, _y)
+
             GL.glDrawPixels(w, h,
                             GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, numpy.fromstring(data, dtype='uint8'))
 
@@ -133,6 +140,15 @@ class GLDisplayContext(object):
             display.set_icon(icon)
         except Exception, e:
             logging.warning('Unable to set icon: {0!r}'.format(e))
+
+        # Let initialize OpenGL stuff after the splash.
+        GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
+        GL.glAlphaFunc(GL.GL_NOTEQUAL, 0)
+        GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+ 
+        # textures are 256x256, so with this we can specify pixel coordinates
+        GL.glMatrixMode(GL.GL_TEXTURE)
+        GL.glScale(1 / 256., 1 / 256., 1 / 256.)
 
         self.display = d
 

--- a/utilities/gl_display_context.py
+++ b/utilities/gl_display_context.py
@@ -31,7 +31,7 @@ class GLDisplayContext(object):
 
     @staticmethod
     def displayMode():
-        return pygame.OPENGL | pygame.RESIZABLE | pygame.DOUBLEBUF | pygame.OPENGLBLIT
+        return pygame.OPENGL | pygame.RESIZABLE | pygame.DOUBLEBUF
 
     def reset(self, splash=None, caption=("", "")):
         pygame.key.set_repeat(500, 100)
@@ -102,10 +102,6 @@ class GLDisplayContext(object):
                 print "wwh 2", wwh
 
         if splash:
-            # Let initialize OpenGL stuff after the splash.
-#             GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
-            #!# The next line can be removed (Linux, from source).
-            # GL.glWindowPos2d(0, 0)
             back = Surface(wwh)
             back.fill((0, 0, 0))
             GL.glDrawPixels(wwh[0], wwh[1], GL.GL_RGBA, GL.GL_UNSIGNED_BYTE,
@@ -114,10 +110,9 @@ class GLDisplayContext(object):
             _x, _y = (wwh[0] / 2 - swh[0] / 2, wwh[1] / 2 - swh[1] / 2)
             w, h = swh
             data = image.tostring(splash, 'RGBA', 1)
-            GL.glWindowPos2d(_x, _y)
+            GL.glWindowPos3d(_x, _y, 0)
             GL.glDrawPixels(w, h,
                             GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, numpy.fromstring(data, dtype='uint8'))
-#             d.blit(splash, (0, 0))
 
         if splash:
             display.flip()
@@ -130,18 +125,6 @@ class GLDisplayContext(object):
             self.win.set_position((x, y), update=True)
             if DEBUG_WM:
                 print "* self.win.get_position()", self.win.get_position()
-
-        # Initialize OpenGL stuff now.
-#         GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
-#         GL.glAlphaFunc(GL.GL_NOTEQUAL, 0)
-#         GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
-# 
-#         # textures are 256x256, so with this we can specify pixel coordinates
-#         GL.glMatrixMode(GL.GL_TEXTURE)
-#         GL.glScale(1 / 256., 1 / 256., 1 / 256.)
-#         
-#         GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
-
 
         try:
             iconpath = os.path.join(directories.getDataDir(), 'favicon.png')


### PR DESCRIPTION
The 'glWindowPos2d' bug is fixed by regressing to OpenGL 1.1, due to Intel and Microsoft regression of some of their drivers in Windows 10.