### PR TITLE
CameraViewport: don't capture mouse while modal dialog is open

### DIFF
--- a/viewports/camera.py
+++ b/viewports/camera.py
@@ -31,6 +31,7 @@ from albow.dialogs import Dialog, wrapped_label
 from albow.openglwidgets import GLViewport
 from albow.extended_widgets import BasicTextInputRow, CheckBoxLabel
 from albow.translate import _
+from albow.root import get_top_widget
 from pygame import mouse
 from depths import DepthOffset
 from editortools.operation import Operation
@@ -1505,7 +1506,8 @@ class CameraViewport(GLViewport):
         self.toggleMouseLook()
 
     def rightClickUp(self, evt):
-        if not self.should_lock and self.editor.level:
+        if (not self.should_lock and self.editor.level and
+                not get_top_widget().is_modal):
             self.toggleMouseLook()
         # if self.rightMouseDragStart is None:
         #     return


### PR DESCRIPTION
Potential fix for #724.

I've traced the bug back to the fact that the modal dialog loop (RootWidget.run_modal) forwards mouse events outside the modal dialog back to the last mouse event handler, which is the camera viewport, and the camera viewport then interprets the mouse up event as the user wanting to toggle mouse capture.

The easiest fix seemed to be to directly check in CameraViewport.rightClickUp if there is any active modal window, and if so ignore the event. That's what this PR does. It fixed the bug for me, and I couldn't immediately see any other regressions caused by the fix (but I only tested for a short amount of time).