### PR TITLE
Temporarily adding missing strings

### DIFF
--- a/lang/zh_CN.trn
+++ b/lang/zh_CN.trn
@@ -2059,3 +2059,12 @@ o955 Sets the maximum view distance for the renderer. Values over 32 can possibl
 t955 设置渲染的最大距离. 数值大于32可能导致软件不稳定，设置前请了解操作风险
 o956 Updated %s filter(s) out of %s
 t956 已更新 %s 个滤镜，共 %s 个待更新滤镜
+# 299 ~ 300
+o957 BanSlimes
+t957 禁止史莱姆
+# 778 ~ 779
+o958 Legacy Mode (Pre 1.9)
+t958 旧版模式（1.9之前）
+# 306 ~ 307
+o959 Air
+t959 氧气值

--- a/stock-filters/NBTEdit.py
+++ b/stock-filters/NBTEdit.py
@@ -2,8 +2,8 @@ import ast
 from pymclevel.box import BoundingBox
 
 inputs = [(("Entities", True),
-           ("Tile Entities", True),
-           ("Tile Ticks", True),
+           ("TileEntities", True),
+           ("TileTicks", True),
            ("Options", "title")),
           (("Results", "title"),
            ("", ["NBTTree", {}, 0, False]),
@@ -45,7 +45,7 @@ def perform(level, box, options):
     chunks = []
     boundingBox = box
     data = {"Entities": [], "TileEntities": [], "TileTicks": []}
-    runOn = (options["Entities"], options["Tile Entities"], options["Tile Ticks"])
+    runOn = (options["Entities"], options["TileEntities"], options["TileTicks"])
     for (chunk, slices, point) in level.getChunkSlices(box):
         if runOn[0]:
             for e in chunk.Entities:


### PR DESCRIPTION
I recently messed up my Python 2.7 environment, so I can't run mcedit from source right now. 
@LaChal would you plz spare some time to check this below?

Three new strings are from these stock filters:
Banslimes
Create Shop
Change Mob Attributes

I've added a comment line each to note the number code they should be.
If you have some software to batch change the number, it may be better to move them to the correct places so it's more easily understood. If
not, maybe the comment lines should be better deleted to keep the file
style format more aligned.
Also plz apply the addition to the rest language files, since I don't
know how you will finally deal with it.

Besides, two more strings "Tile Entities", "Tile Ticks"(with space),
which serves for NBTEdit filter, is deleted. Instead of adding them, I
modified the original strings so the filter can make use of the existing
strings "TileEntities" & "TileTicks". I think it should be fine, while I haven't (actually can't) test it.