### PR TITLE
Handle IndexError when rotating/flipping/etc. schematics

### DIFF
--- a/pymclevel/blockrotation.py
+++ b/pymclevel/blockrotation.py
@@ -855,7 +855,7 @@ def masterRotationTable(attrname):
                 # Very bad stuff here...
                 try:
                     table[blocktype] = blocktable
-                except (NameError, ValueError) as e:
+                except (NameError, ValueError, IndexError) as e:
                     try:
                         table[eval(blocktype)] = blocktable
                     except (NameError, SyntaxError):


### PR DESCRIPTION
When trying to rotate, roll, flip or mirror a schematic, I get this IndexError:

![rotate](https://user-images.githubusercontent.com/11667279/27508156-18006904-58e8-11e7-82ad-3f0c6193d84b.png)

```
Traceback (most recent call last):
  File "E:\Packages\MCEdit-Unified\mceutils.py", line 53, in _alertException
    return func(*args, **kw)
  File "E:\Packages\MCEdit-Unified\editortools\clone.py", line 855, in mirror
    self.level.flipNorthSouth()
  File "E:\Packages\MCEdit-Unified\pymclevel\schematic.py", line 429, in flipNorthSouth
    blockrotation.FlipNorthSouth(self.Blocks, self.Data)
  File "E:\Packages\MCEdit-Unified\pymclevel\blockrotation.py", line 943, in FlipNorthSouth
    data[:] = BlockRotation().flipNorthSouth[blocks, data]
  File "E:\Packages\MCEdit-Unified\pymclevel\blockrotation.py", line 925, in __init__
    self.rotateLeft = masterRotationTable("rotateLeft")
  File "E:\Packages\MCEdit-Unified\pymclevel\blockrotation.py", line 857, in masterRotationTable
    table[blocktype] = blocktable
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```

This is on the current master (237fcb8), with Python 2.7.13, in a virtualenv:

```
> pip list
Cython (0.21.2)
ftputil (3.3.1)
numpy (1.9.3)
Pillow (2.9.0)
pip (9.0.1)
pygame (1.9.3)
PyOpenGL (3.1.0)
pywin32 (221)
PyYAML (3.12)
setuptools (36.0.1)
UNKNOWN (0.0.0, e:\packages\mcedit-unified)
wheel (0.29.0)
```

Adding `IndexError` to `masterRotationTable`'s except statement seems to fix this. I was able to successfully import a flipped schematic - except for an item frame, which was destroyed when loading the world in Minecraft, and the stair blocks, which were all facing the wrong way. (I'm not sure if MCEdit is supposed to have any logic for this, though.)

I'm not familiar with MCEdit's codebase, so let me know if I'm missing the big picture here.