### PR TITLE
 Started implementation of block IDs interface

### DIFF
--- a/mceutils.py
+++ b/mceutils.py
@@ -296,8 +296,9 @@ def loadPNGData(filename_or_data):
 def loadPNGFile(filename):
     (w, h, data) = loadPNGData(filename)
 
-    powers = (16, 32, 64, 128, 256, 512, 1024, 2048, 4096)
-    assert (w in powers) and (h in powers)  # how crude
+    # We need 16*16 sub images in the 'terrain' files for now.
+    # Can we read comments or additional data in PNG files to get the sub-images size like 32*32 or 8*8?
+    assert (w % 16 == 0) and (h % 16 == 0)
 
     return w, h, data
 

--- a/pymclevel/infiniteworld.py
+++ b/pymclevel/infiniteworld.py
@@ -33,7 +33,8 @@ from uuid import UUID
 import id_definitions
 
 # #!# For mod support testing
-from modloader import build_mod_ids_map
+from modloader import build_mod_ids_map, find_mod_jar, ModLoader
+from directories import getDataDir, getMinecraftSaveFileDir
 # #!#
 
 log = getLogger(__name__)
@@ -1271,10 +1272,16 @@ class MCInfdevOldLevel(ChunkedLevelMixin, EntityLevel):
                     self.loadDefIds()
                     # Now check for potential Forge mods in the file.
                     block_ids, mod_entries = build_mod_ids_map(self.root_tag)
-                    print "block_ids", block_ids
+#                     print "block_ids", block_ids
                     print "mod_entries", mod_entries
                     # Send mod object map to modloader.ModLoader to build the definition and texture files.
                     # Before, find the .jar mod files according to the mod_entries dict.
+                    mc_mods_dir = os.path.join(getDataDir(), "mods")
+                    for modid, modver in mod_entries.items():
+                        mod_file = find_mod_jar(modid, modver, (mc_mods_dir,
+                                      os.path.abspath(os.path.join(getMinecraftSaveFileDir(), "..", "mods"))))
+                        if mod_file:
+                            ModLoader(mod_file, mc_mods_dir, block_ids)
             except Exception as e:
                 print "self.root_tag = nbt.load(self.filename) failed", self.filename
                 traceback.print_exc()

--- a/pymclevel/materials.py
+++ b/pymclevel/materials.py
@@ -449,10 +449,10 @@ class MCMaterials(object):
             self.addJSONBlocks(blockyaml)
         else:
             self.addJSONBlocksFromFile(f_name)
-        print sorted(self.__dict__.keys())
+#         print sorted(self.__dict__.keys())
         meth() # TODO: Remove this later, removing now causes things to break
         build_api_material_map(self)
-        print sorted(self.__dict__.keys())
+#         print sorted(self.__dict__.keys())
 #         build_api_material_map()
 
     def addJSONBlocks(self, blockyaml):

--- a/pymclevel/modloader.py
+++ b/pymclevel/modloader.py
@@ -1,0 +1,208 @@
+# mod_loader.py
+#
+# D.C.-G 2017
+#
+# Trying to load directly the mod data from the .jar.
+# Mod used to create this module is Conquest Reforged (conquest_reforged_MOD_v.1.4.51.jar, loaded with Forge).
+# Changes may/will be needed for other mod loading methods.
+#
+# TODO:
+# * Change the print statements for log entries.
+# * Read the Json data to retrieve the elements in the texture_catalog.
+# * Write corresponding .json files using collected data.
+#
+from __future__ import unicode_literals
+import os
+import zipfile
+import json
+import re
+import math
+import traceback
+from PIL import Image
+from cStringIO import StringIO
+
+
+class ModLoader(object):
+    """Loads a mod packed in a .jar file and extract needed information in a
+    directory named like the mod.
+    The destination directory will contin .json definition files and a texture
+    one usable by MCEdit."""
+    def __init__(self, file_name, output_dir):
+        """Initialize the object.
+        :file_name: string: Full path to the .jar file. Must exists!
+        :output_dir: string: The directory where to create the mod content. Must exists!"""
+        print "Loading mod", file_name
+        self.file_name = file_name
+        self.output_dir = output_dir
+
+        # Let define some useful data for forein class/method usage.
+        self.mod_name = None
+        # Full path to the mod directory where self.texture_file and json definitions are.
+        # Will be set to self.output_dir + mod name later.
+        self.mod_dir = None
+        # Textures file name in self.mod_dir.
+        # This file will be built using the ones found in the mod .jar.
+        self.texture_file = None
+        self.mod_info = None
+        self.version = None
+        self.mcversion = None
+        self.modid = None
+        self.texture_catalog = {}
+
+        # Open the jar and finish the initialization.
+        self.__archive = zipfile.ZipFile(file_name)
+        self.__jar_content = self.__archive.namelist()
+        self.__read_mod_info()
+        self.__build_texture()
+        self.__archive.close()
+
+    def __read_mod_info(self):
+        """Reads the .jar root directory to find the 'mcmod.info' json file.
+        Read it and build self.mod_dir, self.mod_name, self.version and self.mcversion.
+        Also set self.mod_info to the parsed json object.
+        If 'mcmod.info' is not found, let try to guess..."""
+        arch = self.__archive
+        mod_info = {}
+        if "mcmod.info" in self.__jar_content:
+            data = arch.read("mcmod.info").strip("[").strip("]")
+            # The dependecies are a list of unquoted words. Fix that!
+            deps = re.search(r'^[ ]*?"dependencies"[ ]*?:[ ]*?\[.*?\]$', data, re.M)
+            if deps:
+                head, _deps = deps.group().split("[")
+                _deps = [a.strip() for a in _deps.split("]")[0].split(",")]
+                repl = head + '["' + '", "'.join(_deps) + '"]'
+                data = data.replace(deps.group(), repl)
+            try:
+                mod_info = json.loads(data)
+            except Exception as exc:
+                print "Can't load mod info because:"
+                traceback.print_exc()
+        self.mod_info = mod_info
+        # Let define some default values in mcmod.info don't contain them.
+        mod_name = os.path.splitext(self.file_name)[0]
+        self.mod_name = mod_info.get("name", mod_name)
+        self.version = mod_info.get("version", mod_name)
+        self.mcversion = mod_info.get("mcversion", "Unknown")
+        dir_name = self.mod_name
+        if self.version != mod_name:
+            dir_name += "_%s" % self.version
+        self.mod_dir = os.path.join(self.output_dir, dir_name)
+        self.modid = mod_info.get("modid", mod_name)
+
+        print "Mod info:"
+        print "  * self.mod_name: ", self.mod_name
+        print "  * self.vesrion:  ", self.version
+        print "  * self.mcversion:", self.mcversion
+        print "  * self.modid:    ", self.modid
+        print "  * self.mod_dir:  ", self.mod_dir
+        print "  * self.mod_info: ", self.mod_info
+
+
+    def __build_texture(self):
+        """Build a texture file from the one found in the mod."""
+
+        def get_16x16_image(fp):
+            """Load an image and resize it to 16*16 pixels.
+            :fp: file object: opened file descriptor to read the image."""
+            img = Image.open(fp)
+            if img.size != (16, 16):
+                return img.resize((16, 16))
+            return img
+
+        mod_dir = self.mod_dir
+        # Create the mod_dir.
+        if not os.path.exists(mod_dir):
+            os.makedirs(mod_dir)
+
+        jar_content = self.__jar_content
+        arch = self.__archive
+
+        pat = "assets{0}.*?{0}textures".format(os.path.sep)
+        textures_entries = [a for a in jar_content if re.match(pat, a) and a.endswith(".png")]
+        textures_num = len(textures_entries)
+
+        if textures_num:
+            _s = math.sqrt(textures_num)
+            sq_root = int(round(_s))
+            # WARNING: textue_size is in tiles of 16*16 pixels, so a size of 4*4 will be a 64*64 pixels image!
+            texture_size = (sq_root, sq_root)
+            image_size = (sq_root * 16, sq_root * 16)
+    
+#             print "textures_num", textures_num
+#             print "_s", _s
+#             print "sq_root", sq_root
+#             print "texture_size", texture_size
+#             print "verif: sq_root * sq_root, all_texture_num", sq_root * sq_root, textures_num
+            
+            print "Mod textures number:", textures_num
+            print "Mod texture size (in 16*16 pxels tiles:", texture_size
+    
+            # ===============================================================
+            # Texture file creation and population
+            #
+            # Also populate a catalog like {"texture_name": [offset_x, offset_y]}
+            # This catalog will be used later by MCEdit to get the image in the texture
+            # and to write json data.
+            # "texture_name" is the image file name found in the .jar, without extension.
+            #
+            # ===============================================================
+            # Create the new texture image.
+            texture_catalog = {}
+
+            # Store the tile offsets
+            offset_x, offset_y = 0, 0
+
+            self.texture_file = texture_file = os.path.join(mod_dir, "terrain.png")
+
+            background_color = (107, 63, 127)
+            foreground_color = (214, 127, 255)
+
+            texture = Image.new("RGBA", image_size, color=background_color)
+            print "Mod texture size:", texture.size
+
+            # Populate it with the mod textures.
+            print "Populating texture with mod ones."
+            for img_path in textures_entries:
+                fdata = arch.read(img_path)
+                fimg = StringIO(fdata)
+                img = get_16x16_image(fimg)
+                x, y = offset_x * 16, offset_y * 16
+                w, h = x + 16, y + 16
+#                 print "Pasting at", offset_x, offset_y, img_path
+                texture.paste(img, (x, y, w, h))
+                texture_catalog[os.path.splitext(os.path.split(img_path)[1])[0]] = (offset_x, offset_y)
+                if offset_x < texture_size[0] - 1:
+                    offset_x += 1
+                else:
+                    offset_x = 0
+                    offset_y += 1
+
+            self.texture_catalog = texture_catalog
+
+            # Finish by drawing foreground_color squares where no other image ha been put.
+            print "Filling up mod texture with default one."
+            notex = Image.new("RGBA", (14, 14), color=foreground_color)
+            while (offset_x * offset_y) < textures_num:
+                x, y = (offset_x * 16) + 1, (offset_y * 16) + 1
+                w, h = x + 14, y + 14
+                texture.paste(notex, (x, y, w, h))
+                if offset_x < texture_size[0] - 1:
+                    offset_x += 1
+                else:
+                    offset_x = 0
+                    offset_y += 1
+#             print "offsets:", offset_x, offset_y
+
+            # Finally, save the file
+            texture.save(texture_file, "png")
+            print "Texture file saved:", texture_file
+
+
+# ------------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Let use this for tests :)
+    import sys
+    # modloader.py <jar_file> <output_dir>
+    loader = ModLoader(sys.argv[1], sys.argv[2])
+#     print loader.__dict__
+    print loader.texture_catalog

--- a/pymclevel/modloader.py
+++ b/pymclevel/modloader.py
@@ -87,7 +87,7 @@ class ModLoader(object):
         arch = self.__archive
         mod_info = {}
         if "mcmod.info" in self.__jar_content:
-            data = arch.read("mcmod.info").strip("[").strip("]")
+            data = arch.read("mcmod.info").strip().strip("[").strip("]")
             # The dependecies are a list of unquoted words. Fix that!
             deps = re.search(r'^[ ]*?"dependencies"[ ]*?:[ ]*?\[.*?\]$', data, re.M)
             if deps:
@@ -102,11 +102,16 @@ class ModLoader(object):
                 traceback.print_exc()
         self.mod_info = mod_info
         # Let define some default values in mcmod.info don't contain them.
-        mod_name = os.path.splitext(self.file_name)[0]
-        self.mod_name = mod_info.get("name", mod_name)
-        self.version = mod_info.get("version", mod_name)
-        self.mcversion = mod_info.get("mcversion", "Unknown")
-        self.modid = mod_info.get("modid", mod_name)
+        mod_name = os.path.split(os.path.splitext(self.file_name)[0])[1]
+        if isinstance(mod_info, dict):
+            if mod_info.get("modListVersion", 0) == 2:
+                info = mod_info.get("modList", [{}])[0]
+            else:
+                info = mod_info
+        self.mod_name = info.get("name", mod_name)
+        self.version = info.get("version", mod_name)
+        self.mcversion = info.get("mcversion", "Unknown")
+        self.modid = info.get("modid", mod_name)
         # dir_name = self.mod_name
         dir_name = self.modid
         if self.version != mod_name:

--- a/pymclevel/modloader.py
+++ b/pymclevel/modloader.py
@@ -28,13 +28,18 @@ class ModLoader(object):
     directory named like the mod.
     The destination directory will contain .json definition files and a texture
     one usable by MCEdit."""
-    def __init__(self, file_name, output_dir):
+    def __init__(self, file_name, output_dir, block_ids={}, force=False):
         """Initialize the object.
         :file_name: string: Full path to the .jar file. Must exists!
-        :output_dir: string: The directory where to create the mod content. Must exists!"""
+        :output_dir: string: The directory where to create the mod content. Must exists!
+        :block_ids: dict: If given, keys are block 'idStr' and values numeric IDs as found in the mod definition in 'level.dat'
+            Defaults to an empty dict.
+        :force: bool: Whether to force a mod extracted data to be overwritten.
+            Defaults to False. ! ! NOT IMPLEMENTED ! !"""
         print "Loading mod", file_name
         self.file_name = file_name
         self.output_dir = output_dir
+        self.block_ids = block_ids
 
         # Let define some useful data for forein class/method usage.
         self.mod_name = None
@@ -236,9 +241,8 @@ class ModLoader(object):
         if d_type not in built_json[namespace].keys():
             built_json[namespace][d_type] = []
 
-        # Numeric IDs are added according to the order of the files in the .jar.
-        # They sahll not be used 'as is' by MCEdit.
-        oid = len(built_json[namespace][d_type]) + 1
+        # Numeric IDs are added according to self.block_ids or the order of the files in the .jar.
+        oid = self.block_ids.get(name, 0) or len(built_json[namespace][d_type]) + 1
 
         built_json[namespace][d_type].append({"id": oid,
                                               "idStr": name,

--- a/pymclevel/modloader.py
+++ b/pymclevel/modloader.py
@@ -133,7 +133,7 @@ class ModLoader(object):
         jar_content = self.__jar_content
         arch = self.__archive
 
-        pat = "assets{0}.*?{0}textures".format(os.path.sep)
+        pat = "assets/.*?/textures"
         textures_entries = [a for a in jar_content if re.match(pat, a) and a.endswith(".png")]
         textures_num = len(textures_entries)
 
@@ -249,7 +249,7 @@ class ModLoader(object):
         Data is then contained in self.blocks"""
         arch = self.__archive
         jar_content = self.__jar_content
-        pat = "assets{0}.*?{0}models{0}block".format(os.path.sep)
+        pat = "assets/.*?/models/block"
         blocks_entries = [a for a in jar_content if re.match(pat, a) and a.endswith(".json")]
 
         # 'assets' can contain several directories with textures an json definitions.
@@ -258,7 +258,7 @@ class ModLoader(object):
         # So let use these directory names as 'namespaces'
 
         blocks = {}
-        namespace_pat = "assets{0}(.*?){0}models{0}block".format(os.path.sep)
+        namespace_pat = "assets/(.*?)/models/block"
         blocks_num = 0
 
         for entry in blocks_entries:

--- a/pymclevel/modloader.py
+++ b/pymclevel/modloader.py
@@ -95,6 +95,11 @@ class ModLoader(object):
                 _deps = [a.strip() for a in _deps.split("]")[0].split(",")]
                 repl = head + '["' + '", "'.join(_deps) + '"]'
                 data = data.replace(deps.group(), repl)
+            # Some mcmod.info files can contain multy line string as values.
+            # Since it is not permited for the json Python support, let fix it.
+            results = re.findall(r'".*?"[ ]*?:[ ]*?"(.*?)",', data, re.M|re.S)
+            for result in results:
+                data = data.replace(result, result.replace("\n", "\\n"))
             try:
                 mod_info = json.loads(data)
             except Exception as exc:

--- a/pymclevel/modloader.py
+++ b/pymclevel/modloader.py
@@ -141,9 +141,15 @@ class ModLoader(object):
             _s = math.sqrt(textures_num)
             sq_root = int(round(_s))
             # WARNING: textue_size is in tiles of 16*16 pixels, so a size of 4*4 will be a 64*64 pixels image!
-            texture_size = (sq_root, sq_root)
-            image_size = (sq_root * 16, sq_root * 16)
-            self.notex_idx = sq_root - 1, sq_root - 1
+            plus = 0 # width
+            pluss = [sq_root, sq_root]
+            while (pluss[0] * pluss[1]) < textures_num:
+                pluss[plus] += 1
+                plus = int(not plus)
+            width, height = pluss
+            texture_size = width, height
+            image_size = (width * 16, height * 16)
+            self.notex_idx = width - 1, height - 1
     
 #             print "textures_num", textures_num
 #             print "_s", _s


### PR DESCRIPTION
The keyword argument 'block_ids' (dict) can be given to modloader.Modloader
to have a correct mapping between block string IDs ('idStr') and numeric
IDs ('id').
This dict shall be built when reading the 'level.dat' file, using the FML
definitions. << Done in the [Basic .jar mod file finding](https://github.com/Khroki/MCEdit-Unified/pull/871/commits/7b4d7bf3dcf9d5b325e12cfcd1fc4c926bf3d6f9) commit.