### PR TITLE
Mod handling optimization, refactor, render tests.

### DIFF
--- a/albow/file_opener.py
+++ b/albow/file_opener.py
@@ -68,7 +68,7 @@ class FileOpener(albow.Widget):
             shortname = os.path.basename(world)
             try:
                 if pymclevel.MCInfdevOldLevel.isLevel(world):
-                    lev = pymclevel.MCInfdevOldLevel(world, readonly=True)
+                    lev = pymclevel.MCInfdevOldLevel(world, readonly=True, check_only=True)
                     shortname = lev.LevelName
                     if lev.LevelName != lev.displayName:
                         shortname = u"{0} ({1})".format(lev.LevelName, lev.displayName)

--- a/leveleditor.py
+++ b/leveleditor.py
@@ -1181,7 +1181,7 @@ class LevelEditor(GLViewport):
         GL.glDisable(GL.GL_BLEND)
         GL.glDisable(GL.GL_DEPTH_TEST)
 
-    def loadFile(self, filename, addToRecent=True):
+    def loadFile(self, filename, addToRecent=True, check_only=False):
         """
         Called when the user picks a level using Load World or Open File.
         """
@@ -1199,7 +1199,7 @@ class LevelEditor(GLViewport):
             self.level.close()
 
         try:
-            level = pymclevel.fromFile(filename)
+            level = pymclevel.fromFile(filename, check_only=check_only)
         except Exception as e:
             logging.exception(
                 'Wasn\'t able to open a file {file => %s}' % filename

--- a/mcedit.py
+++ b/mcedit.py
@@ -680,10 +680,10 @@ class MCEdit(GLViewport):
 
     shouldResizeAlert = config.settings.shouldResizeAlert.property()
 
-    def loadFile(self, filename, addToRecent=True):
+    def loadFile(self, filename, addToRecent=True, check_only=False):
         if os.path.exists(filename):
             try:
-                self.editor.loadFile(filename, addToRecent=addToRecent)
+                self.editor.loadFile(filename, addToRecent=addToRecent, check_only=check_only)
             except Exception as e:
                 traceback.print_exc()
                 logging.error(u'Failed to load file {0}: {1!r}'.format(

--- a/mceutils.py
+++ b/mceutils.py
@@ -40,6 +40,10 @@ import pymclevel
 
 import logging
 
+from gl_img_utils import drawFace, drawCube, drawTerrainCuttingWire, \
+    loadAlphaTerrainTexture, loadPNGData, loadPNGFile, loadTextureFunc, \
+    loadPNGTexture, normalize, normalize_size
+
 #!# Used to track the ALBOW stuff imported from here
 def warn(obj):
     name = getattr(obj, '__name__', getattr(getattr(obj, '__class__', obj), '__name__', obj))
@@ -61,287 +65,291 @@ def alertException(func):
     return _alertException
 
 
-def drawFace(box, face, type=GL.GL_QUADS):
-    x, y, z, = box.origin
-    x2, y2, z2 = box.maximum
+# ======================================================================
+# ! ! ! MOVED TO 'gl_img_utils.py' TO AVOID CYCLIC IMPORTS
 
-    if face == pymclevel.faces.FaceXDecreasing:
-
-        faceVertices = numpy.array(
-            (x, y2, z2,
-             x, y2, z,
-             x, y, z,
-             x, y, z2,
-            ), dtype='f4')
-
-    elif face == pymclevel.faces.FaceXIncreasing:
-
-        faceVertices = numpy.array(
-            (x2, y, z2,
-             x2, y, z,
-             x2, y2, z,
-             x2, y2, z2,
-            ), dtype='f4')
-
-    elif face == pymclevel.faces.FaceYDecreasing:
-        faceVertices = numpy.array(
-            (x2, y, z2,
-             x, y, z2,
-             x, y, z,
-             x2, y, z,
-            ), dtype='f4')
-
-    elif face == pymclevel.faces.FaceYIncreasing:
-        faceVertices = numpy.array(
-            (x2, y2, z,
-             x, y2, z,
-             x, y2, z2,
-             x2, y2, z2,
-            ), dtype='f4')
-
-    elif face == pymclevel.faces.FaceZDecreasing:
-        faceVertices = numpy.array(
-            (x, y, z,
-             x, y2, z,
-             x2, y2, z,
-             x2, y, z,
-            ), dtype='f4')
-
-    elif face == pymclevel.faces.FaceZIncreasing:
-        faceVertices = numpy.array(
-            (x2, y, z2,
-             x2, y2, z2,
-             x, y2, z2,
-             x, y, z2,
-            ), dtype='f4')
-
-    faceVertices.shape = (4, 3)
-    dim = face >> 1
-    dims = [0, 1, 2]
-    dims.remove(dim)
-
-    texVertices = numpy.array(
-        faceVertices[:, dims],
-        dtype='f4'
-    ).flatten()
-    faceVertices.shape = (12,)
-
-    texVertices *= 16
-    GL.glEnableClientState(GL.GL_TEXTURE_COORD_ARRAY)
-
-    GL.glVertexPointer(3, GL.GL_FLOAT, 0, faceVertices)
-    GL.glTexCoordPointer(2, GL.GL_FLOAT, 0, texVertices)
-
-    GL.glEnable(GL.GL_POLYGON_OFFSET_FILL)
-    GL.glEnable(GL.GL_POLYGON_OFFSET_LINE)
-
-    if type is GL.GL_LINE_STRIP:
-        indexes = numpy.array((0, 1, 2, 3, 0), dtype='uint32')
-        GL.glDrawElements(type, 5, GL.GL_UNSIGNED_INT, indexes)
-    else:
-        GL.glDrawArrays(type, 0, 4)
-    GL.glDisable(GL.GL_POLYGON_OFFSET_FILL)
-    GL.glDisable(GL.GL_POLYGON_OFFSET_LINE)
-    GL.glDisableClientState(GL.GL_TEXTURE_COORD_ARRAY)
-
-
-def drawCube(box, cubeType=GL.GL_QUADS, blockType=0, texture=None, textureVertices=None, selectionBox=False):
-    """ pass a different cubeType e.g. GL_LINE_STRIP for wireframes """
-    x, y, z, = box.origin
-    x2, y2, z2 = box.maximum
-    dx, dy, dz = x2 - x, y2 - y, z2 - z
-    cubeVertices = numpy.array(
-        (
-            x, y, z,
-            x, y2, z,
-            x2, y2, z,
-            x2, y, z,
-
-            x2, y, z2,
-            x2, y2, z2,
-            x, y2, z2,
-            x, y, z2,
-
-            x2, y, z2,
-            x, y, z2,
-            x, y, z,
-            x2, y, z,
-
-            x2, y2, z,
-            x, y2, z,
-            x, y2, z2,
-            x2, y2, z2,
-
-            x, y2, z2,
-            x, y2, z,
-            x, y, z,
-            x, y, z2,
-
-            x2, y, z2,
-            x2, y, z,
-            x2, y2, z,
-            x2, y2, z2,
-        ), dtype='f4')
-    if textureVertices is None:
-        textureVertices = numpy.array(
-            (
-                0, -dy * 16,
-                0, 0,
-                dx * 16, 0,
-                dx * 16, -dy * 16,
-
-                dx * 16, -dy * 16,
-                dx * 16, 0,
-                0, 0,
-                0, -dy * 16,
-
-                dx * 16, -dz * 16,
-                0, -dz * 16,
-                0, 0,
-                dx * 16, 0,
-
-                dx * 16, 0,
-                0, 0,
-                0, -dz * 16,
-                dx * 16, -dz * 16,
-
-                dz * 16, 0,
-                0, 0,
-                0, -dy * 16,
-                dz * 16, -dy * 16,
-
-                dz * 16, -dy * 16,
-                0, -dy * 16,
-                0, 0,
-                dz * 16, 0,
-
-            ), dtype='f4')
-
-        textureVertices.shape = (6, 4, 2)
-
-        if selectionBox:
-            textureVertices[0:2] += (16 * (x & 15), 16 * (y2 & 15))
-            textureVertices[2:4] += (16 * (x & 15), -16 * (z & 15))
-            textureVertices[4:6] += (16 * (z & 15), 16 * (y2 & 15))
-            textureVertices[:] += 0.5
-
-    GL.glVertexPointer(3, GL.GL_FLOAT, 0, cubeVertices)
-    if texture is not None:
-        GL.glEnable(GL.GL_TEXTURE_2D)
-        GL.glEnableClientState(GL.GL_TEXTURE_COORD_ARRAY)
-
-        texture.bind()
-        GL.glTexCoordPointer(2, GL.GL_FLOAT, 0, textureVertices),
-
-    GL.glEnable(GL.GL_POLYGON_OFFSET_FILL)
-    GL.glEnable(GL.GL_POLYGON_OFFSET_LINE)
-
-    GL.glDrawArrays(cubeType, 0, 24)
-    GL.glDisable(GL.GL_POLYGON_OFFSET_FILL)
-    GL.glDisable(GL.GL_POLYGON_OFFSET_LINE)
-
-    if texture is not None:
-        GL.glDisableClientState(GL.GL_TEXTURE_COORD_ARRAY)
-        GL.glDisable(GL.GL_TEXTURE_2D)
-
-
-def drawTerrainCuttingWire(box,
-                           c0=(0.75, 0.75, 0.75, 0.4),
-                           c1=(1.0, 1.0, 1.0, 1.0)):
-    # glDepthMask(False)
-    GL.glEnable(GL.GL_DEPTH_TEST)
-
-    GL.glDepthFunc(GL.GL_LEQUAL)
-    GL.glColor(*c1)
-    GL.glLineWidth(2.0)
-    drawCube(box, cubeType=GL.GL_LINE_STRIP)
-
-    GL.glDepthFunc(GL.GL_GREATER)
-    GL.glColor(*c0)
-    GL.glLineWidth(1.0)
-    drawCube(box, cubeType=GL.GL_LINE_STRIP)
-
-    GL.glDepthFunc(GL.GL_LEQUAL)
-    GL.glDisable(GL.GL_DEPTH_TEST)
-    # glDepthMask(True)
-
-
-def loadAlphaTerrainTexture():
-    texW, texH, terraindata = loadPNGFile(os.path.join(directories.getDataDir(),  ResourcePackHandler.Instance().get_selected_resource_pack().terrain_path()))
-
-    def _loadFunc():
-        loadTextureFunc(texW, texH, terraindata)
-
-    tex = glutils.Texture(_loadFunc)
-    tex.data = terraindata
-    return tex
-
-
-def loadPNGData(filename_or_data):
-    reader = png.Reader(filename_or_data)
-    (w, h, data, metadata) = reader.read_flat()
-    data = numpy.array(data, dtype='uint8')
-    data.shape = (h, w, metadata['planes'])
-    if data.shape[2] == 1:
-        # indexed color. remarkably straightforward.
-        data.shape = data.shape[:2]
-        data = numpy.array(reader.palette(), dtype='uint8')[data]
-
-    if data.shape[2] < 4:
-        data = numpy.insert(data, 3, 255, 2)
-
-    return w, h, data
-
-
-def loadPNGFile(filename):
-    (w, h, data) = loadPNGData(filename)
-
-    # We need 16*16 sub images in the 'terrain' files for now.
-    # Can we read comments or additional data in PNG files to get the sub-images size like 32*32 or 8*8?
-    assert (w % 16 == 0) and (h % 16 == 0)
-
-    return w, h, data
-
-def loadTextureFunc(w, h, ndata):
-    GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA, w, h, 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, ndata)
-    return w, h
-
-
-def loadPNGTexture(filename, *a, **kw):
-    filename = os.path.join(directories.getDataDir(), filename)
-    try:
-        w, h, ndata = loadPNGFile(filename)
-
-        tex = glutils.Texture(functools.partial(loadTextureFunc, w, h, ndata), *a, **kw)
-        tex.data = ndata
-        return tex
-    except Exception as e:
-        print "Exception loading ", filename, ": ", repr(e)
-        return glutils.Texture()
-
-
-import glutils
-
-
-def normalize(x):
-    l = x[0] * x[0] + x[1] * x[1] + x[2] * x[2]
-    if l <= 0.0:
-        return [0, 0, 0]
-    size = numpy.sqrt(l)
-    if size <= 0.0:
-        return [0, 0, 0]
-    return map(lambda a: a / size, x)
-
-
-def normalize_size(x):
-    l = x[0] * x[0] + x[1] * x[1] + x[2] * x[2]
-    if l <= 0.0:
-        return [0., 0., 0.], 0.
-    size = numpy.sqrt(l)
-    if size <= 0.0:
-        return [0, 0, 0], 0
-    return (x / size), size
-
+# def drawFace(box, face, type=GL.GL_QUADS):
+#     x, y, z, = box.origin
+#     x2, y2, z2 = box.maximum
+# 
+#     if face == pymclevel.faces.FaceXDecreasing:
+# 
+#         faceVertices = numpy.array(
+#             (x, y2, z2,
+#              x, y2, z,
+#              x, y, z,
+#              x, y, z2,
+#             ), dtype='f4')
+# 
+#     elif face == pymclevel.faces.FaceXIncreasing:
+# 
+#         faceVertices = numpy.array(
+#             (x2, y, z2,
+#              x2, y, z,
+#              x2, y2, z,
+#              x2, y2, z2,
+#             ), dtype='f4')
+# 
+#     elif face == pymclevel.faces.FaceYDecreasing:
+#         faceVertices = numpy.array(
+#             (x2, y, z2,
+#              x, y, z2,
+#              x, y, z,
+#              x2, y, z,
+#             ), dtype='f4')
+# 
+#     elif face == pymclevel.faces.FaceYIncreasing:
+#         faceVertices = numpy.array(
+#             (x2, y2, z,
+#              x, y2, z,
+#              x, y2, z2,
+#              x2, y2, z2,
+#             ), dtype='f4')
+# 
+#     elif face == pymclevel.faces.FaceZDecreasing:
+#         faceVertices = numpy.array(
+#             (x, y, z,
+#              x, y2, z,
+#              x2, y2, z,
+#              x2, y, z,
+#             ), dtype='f4')
+# 
+#     elif face == pymclevel.faces.FaceZIncreasing:
+#         faceVertices = numpy.array(
+#             (x2, y, z2,
+#              x2, y2, z2,
+#              x, y2, z2,
+#              x, y, z2,
+#             ), dtype='f4')
+# 
+#     faceVertices.shape = (4, 3)
+#     dim = face >> 1
+#     dims = [0, 1, 2]
+#     dims.remove(dim)
+# 
+#     texVertices = numpy.array(
+#         faceVertices[:, dims],
+#         dtype='f4'
+#     ).flatten()
+#     faceVertices.shape = (12,)
+# 
+#     texVertices *= 16
+#     GL.glEnableClientState(GL.GL_TEXTURE_COORD_ARRAY)
+# 
+#     GL.glVertexPointer(3, GL.GL_FLOAT, 0, faceVertices)
+#     GL.glTexCoordPointer(2, GL.GL_FLOAT, 0, texVertices)
+# 
+#     GL.glEnable(GL.GL_POLYGON_OFFSET_FILL)
+#     GL.glEnable(GL.GL_POLYGON_OFFSET_LINE)
+# 
+#     if type is GL.GL_LINE_STRIP:
+#         indexes = numpy.array((0, 1, 2, 3, 0), dtype='uint32')
+#         GL.glDrawElements(type, 5, GL.GL_UNSIGNED_INT, indexes)
+#     else:
+#         GL.glDrawArrays(type, 0, 4)
+#     GL.glDisable(GL.GL_POLYGON_OFFSET_FILL)
+#     GL.glDisable(GL.GL_POLYGON_OFFSET_LINE)
+#     GL.glDisableClientState(GL.GL_TEXTURE_COORD_ARRAY)
+# 
+# 
+# def drawCube(box, cubeType=GL.GL_QUADS, blockType=0, texture=None, textureVertices=None, selectionBox=False):
+#     """ pass a different cubeType e.g. GL_LINE_STRIP for wireframes """
+#     x, y, z, = box.origin
+#     x2, y2, z2 = box.maximum
+#     dx, dy, dz = x2 - x, y2 - y, z2 - z
+#     cubeVertices = numpy.array(
+#         (
+#             x, y, z,
+#             x, y2, z,
+#             x2, y2, z,
+#             x2, y, z,
+# 
+#             x2, y, z2,
+#             x2, y2, z2,
+#             x, y2, z2,
+#             x, y, z2,
+# 
+#             x2, y, z2,
+#             x, y, z2,
+#             x, y, z,
+#             x2, y, z,
+# 
+#             x2, y2, z,
+#             x, y2, z,
+#             x, y2, z2,
+#             x2, y2, z2,
+# 
+#             x, y2, z2,
+#             x, y2, z,
+#             x, y, z,
+#             x, y, z2,
+# 
+#             x2, y, z2,
+#             x2, y, z,
+#             x2, y2, z,
+#             x2, y2, z2,
+#         ), dtype='f4')
+#     if textureVertices is None:
+#         textureVertices = numpy.array(
+#             (
+#                 0, -dy * 16,
+#                 0, 0,
+#                 dx * 16, 0,
+#                 dx * 16, -dy * 16,
+# 
+#                 dx * 16, -dy * 16,
+#                 dx * 16, 0,
+#                 0, 0,
+#                 0, -dy * 16,
+# 
+#                 dx * 16, -dz * 16,
+#                 0, -dz * 16,
+#                 0, 0,
+#                 dx * 16, 0,
+# 
+#                 dx * 16, 0,
+#                 0, 0,
+#                 0, -dz * 16,
+#                 dx * 16, -dz * 16,
+# 
+#                 dz * 16, 0,
+#                 0, 0,
+#                 0, -dy * 16,
+#                 dz * 16, -dy * 16,
+# 
+#                 dz * 16, -dy * 16,
+#                 0, -dy * 16,
+#                 0, 0,
+#                 dz * 16, 0,
+# 
+#             ), dtype='f4')
+# 
+#         textureVertices.shape = (6, 4, 2)
+# 
+#         if selectionBox:
+#             textureVertices[0:2] += (16 * (x & 15), 16 * (y2 & 15))
+#             textureVertices[2:4] += (16 * (x & 15), -16 * (z & 15))
+#             textureVertices[4:6] += (16 * (z & 15), 16 * (y2 & 15))
+#             textureVertices[:] += 0.5
+# 
+#     GL.glVertexPointer(3, GL.GL_FLOAT, 0, cubeVertices)
+#     if texture is not None:
+#         GL.glEnable(GL.GL_TEXTURE_2D)
+#         GL.glEnableClientState(GL.GL_TEXTURE_COORD_ARRAY)
+# 
+#         texture.bind()
+#         GL.glTexCoordPointer(2, GL.GL_FLOAT, 0, textureVertices),
+# 
+#     GL.glEnable(GL.GL_POLYGON_OFFSET_FILL)
+#     GL.glEnable(GL.GL_POLYGON_OFFSET_LINE)
+# 
+#     GL.glDrawArrays(cubeType, 0, 24)
+#     GL.glDisable(GL.GL_POLYGON_OFFSET_FILL)
+#     GL.glDisable(GL.GL_POLYGON_OFFSET_LINE)
+# 
+#     if texture is not None:
+#         GL.glDisableClientState(GL.GL_TEXTURE_COORD_ARRAY)
+#         GL.glDisable(GL.GL_TEXTURE_2D)
+# 
+# 
+# def drawTerrainCuttingWire(box,
+#                            c0=(0.75, 0.75, 0.75, 0.4),
+#                            c1=(1.0, 1.0, 1.0, 1.0)):
+#     # glDepthMask(False)
+#     GL.glEnable(GL.GL_DEPTH_TEST)
+# 
+#     GL.glDepthFunc(GL.GL_LEQUAL)
+#     GL.glColor(*c1)
+#     GL.glLineWidth(2.0)
+#     drawCube(box, cubeType=GL.GL_LINE_STRIP)
+# 
+#     GL.glDepthFunc(GL.GL_GREATER)
+#     GL.glColor(*c0)
+#     GL.glLineWidth(1.0)
+#     drawCube(box, cubeType=GL.GL_LINE_STRIP)
+# 
+#     GL.glDepthFunc(GL.GL_LEQUAL)
+#     GL.glDisable(GL.GL_DEPTH_TEST)
+#     # glDepthMask(True)
+# 
+# 
+# def loadAlphaTerrainTexture():
+#     texW, texH, terraindata = loadPNGFile(os.path.join(directories.getDataDir(),  ResourcePackHandler.Instance().get_selected_resource_pack().terrain_path()))
+# 
+#     def _loadFunc():
+#         loadTextureFunc(texW, texH, terraindata)
+# 
+#     tex = glutils.Texture(_loadFunc)
+#     tex.data = terraindata
+#     return tex
+# 
+# 
+# def loadPNGData(filename_or_data):
+#     reader = png.Reader(filename_or_data)
+#     (w, h, data, metadata) = reader.read_flat()
+#     data = numpy.array(data, dtype='uint8')
+#     data.shape = (h, w, metadata['planes'])
+#     if data.shape[2] == 1:
+#         # indexed color. remarkably straightforward.
+#         data.shape = data.shape[:2]
+#         data = numpy.array(reader.palette(), dtype='uint8')[data]
+# 
+#     if data.shape[2] < 4:
+#         data = numpy.insert(data, 3, 255, 2)
+# 
+#     return w, h, data
+# 
+# 
+# def loadPNGFile(filename):
+#     (w, h, data) = loadPNGData(filename)
+# 
+#     # We need 16*16 sub images in the 'terrain' files for now.
+#     # Can we read comments or additional data in PNG files to get the sub-images size like 32*32 or 8*8?
+#     assert (w % 16 == 0) and (h % 16 == 0)
+# 
+#     return w, h, data
+# 
+# def loadTextureFunc(w, h, ndata):
+#     GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA, w, h, 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, ndata)
+#     return w, h
+# 
+# 
+# def loadPNGTexture(filename, *a, **kw):
+#     filename = os.path.join(directories.getDataDir(), filename)
+#     try:
+#         w, h, ndata = loadPNGFile(filename)
+# 
+#         tex = glutils.Texture(functools.partial(loadTextureFunc, w, h, ndata), *a, **kw)
+#         tex.data = ndata
+#         return tex
+#     except Exception as e:
+#         print "Exception loading ", filename, ": ", repr(e)
+#         return glutils.Texture()
+# 
+# 
+# import glutils
+# 
+# 
+# def normalize(x):
+#     l = x[0] * x[0] + x[1] * x[1] + x[2] * x[2]
+#     if l <= 0.0:
+#         return [0, 0, 0]
+#     size = numpy.sqrt(l)
+#     if size <= 0.0:
+#         return [0, 0, 0]
+#     return map(lambda a: a / size, x)
+# 
+# 
+# def normalize_size(x):
+#     l = x[0] * x[0] + x[1] * x[1] + x[2] * x[2]
+#     if l <= 0.0:
+#         return [0., 0., 0.], 0.
+#     size = numpy.sqrt(l)
+#     if size <= 0.0:
+#         return [0, 0, 0], 0
+#     return (x / size), size
+#
+# ======================================================================
 
 # Label = GLLabel
 

--- a/player_cache.py
+++ b/player_cache.py
@@ -5,7 +5,6 @@ import os
 import time
 from PIL import Image
 import atexit
-import threading
 import logging
 from uuid import UUID
 import httplib
@@ -13,61 +12,9 @@ import base64
 import datetime
 import traceback
 
+from utilities.thread_utils import ThreadRS, threadable, threading
+
 log = logging.getLogger(__name__)
-
-
-class ThreadRS(threading.Thread):
-    # This class comes from: http://stackoverflow.com/questions/6893968/how-to-get-the-return-value-from-a-thread-in-python
-    # And may have been tweaked ;)
-    """
-    This class uses a _return instance member to store the result of the underlying Thread object.
-    If 'callbacks' objects are send to the constructor, this '_result' object will be sent to all of them
-    at the end of the 'run' and 'join' method. The latest one also returns '_return' object.
-    """
-    def __init__(self, group=None, target=None, name=None, callbacks=[],
-                 args=(), kwargs={}, Verbose=None):
-        """
-        :callbacks: list: callable objects to send the thread result to.
-        For other arguments, see threading.Thread documentation.
-        """
-        self.target = target
-        self.callbacks = callbacks
-        threading.Thread.__init__(self, group, target, name, args, kwargs, Verbose)
-        self._return = None
-
-    def run(self):
-        if self._Thread__target is not None:
-            self._return = self._Thread__target(*self._Thread__args,
-                                                **self._Thread__kwargs)
-            for callback in self.callbacks:
-                callback(self._return)
-
-    def join(self):
-        try:
-            threading.Thread.join(self)
-        except Exception as e:
-            print e
-        for callback in self.callbacks:
-            callback(self._return)
-        return self._return
-
-    def __repr__(self, *args, **kwargs):
-        return '%s::%s' % (ThreadRS, self.target)
-
-
-def threadable(func):
-    def wrapper(*args, **kwargs):
-        instance = None
-        for arg in args:
-            if isinstance(arg, PlayerCache):
-                instance = arg
-                break
-        with instance.cache_lock:
-            t = ThreadRS(target=func, args=args, kwargs=kwargs, callbacks=instance.targets)
-            t.daemon = True
-            t.start()
-            return t
-    return wrapper
 
 
 #@Singleton

--- a/pymclevel/id_definitions.py
+++ b/pymclevel/id_definitions.py
@@ -48,12 +48,12 @@ from distutils.version import LooseVersion
 
 log = getLogger(__name__)
 
-def update(orig_dict, new_dict):
+def update_dict(orig_dict, new_dict):
     for key, val in new_dict.iteritems():
         if isinstance(val, collections.Mapping):
             if orig_dict.get(key, {}) == val:
                 continue
-            tmp = update(orig_dict.get(key, { }), val)
+            tmp = update_dict(orig_dict.get(key, { }), val)
             orig_dict[key] = tmp
         elif isinstance(val, list):
             if orig_dict.get(key, []) == val:
@@ -213,16 +213,16 @@ def ids_loader(game_version, namespace=u"minecraft", json_dict=False, timestamps
                             if os.path.exists(_file_name):
                                 log.info("Found %s"%_file_name)
                                 #_data.update(_get_data(_file_name))
-                                update(_data, _get_data(_file_name))
+                                update_dict(_data, _get_data(_file_name))
                                 if timestamps:
                                     _timestamps[_file_name] = os.stat(_file_name).st_mtime
                             else:
                                 log.info("Could not find %s"%_file_name)
-                        update(_data, data)
+                        update_dict(_data, data)
                         #_data.update(data)
                         _defs, _ids = _parse_data(_data, prefix, namespace, MCEDIT_DEFS, MCEDIT_IDS, ignore_load=True)
-                        update(MCEDIT_DEFS, _defs)
-                        update(MCEDIT_IDS, _ids)
+                        update_dict(MCEDIT_DEFS, _defs)
+                        update_dict(MCEDIT_IDS, _ids)
                         #MCEDIT_DEFS.update(_defs)
                         #MCEDIT_IDS.update(_ids)
                         if json_dict:

--- a/pymclevel/id_definitions.py
+++ b/pymclevel/id_definitions.py
@@ -126,22 +126,29 @@ def _get_data(file_name):
     return data
 
 
-def ids_loader(game_version, namespace=u"minecraft", json_dict=False, timestamps=False):
+def ids_loader(game_version, namespace=u"minecraft", json_dict=False, timestamps=False, directory=None, update=False):
     """Load the whole files from mcver directory.
     :game_version: str/unicode: the game version for which the resources will be loaded.
     :namespace: unicode: the name to be put in front of some IDs. default to 'minecraft'.
     :json_dict: bool: Whether to return a ran dict from the JSon file(s) instead of the (MCEDIT_DEFS, MCEDIT_IDS) pair.
-    :timestamp: bool: wheter the return also the loaded file timestamp."""
+    :timestamp: bool: wheter the return also the loaded file timestamp.
+    :directory: string: Path to the directory where the json files lie.
+        Defaults to None. In this case, the 'mcver' directory is used, otherwise, 'game_vaerion' is ignored.
+    :update: bool: Whether to update the MCEDIT_DEFS nd MCEDIT_IDS objects. Defaults to False."""
     log.info("Loading resources for MC %s"%game_version)
     global MCEDIT_DEFS
     global MCEDIT_IDS
-    MCEDIT_DEFS = {}
-    MCEDIT_IDS = {}
+    if not update:
+        MCEDIT_DEFS = {}
+        MCEDIT_IDS = {}
     if json_dict:
         _json = {}
     if timestamps:
         _timestamps = {}
-    d = os.path.join('mcver', game_version)
+    if directory is None:
+        d = os.path.join('mcver', game_version)
+    else:
+        d = directory
 
     # If version 1.2.4 files are not found, try to load the one for the closest
     # lower version (like 1.2.3 or 1.2).

--- a/pymclevel/infiniteworld.py
+++ b/pymclevel/infiniteworld.py
@@ -1264,7 +1264,7 @@ class MCInfdevOldLevel(ChunkedLevelMixin, EntityLevel):
             mod_mats = MCMaterials()
             mod_mats.name = "Alpha"
             mod_mats.addJSONBlocksFromVersion(self.gameVersion, mods={mod_obj.modid: mod_obj.mod_dir})
-            self.mod_materials.append(mod_mats)
+            self.mod_materials[mod_obj.modid] = mod_mats
             self.mod_dirs[mod_obj.modid] = mod_obj.mod_dir
 
 
@@ -1300,7 +1300,7 @@ class MCInfdevOldLevel(ChunkedLevelMixin, EntityLevel):
                         self.mc_mods_dir = mc_mods_dir = os.path.join(getDataDir(), "mods")
                         self.mods = mods = {}
                         self.mod_dirs = mod_dirs = {}
-                        self.mod_materials = mod_materials = []
+                        self.mod_materials = mod_materials = {}
 #                         print os.path.dirname(os.path.dirname(self.filename))
 
                         use_threads = False
@@ -1342,12 +1342,12 @@ class MCInfdevOldLevel(ChunkedLevelMixin, EntityLevel):
 #                         print "######################################"
 #                         print "mods", self.mods
 #                         print "lod_dirs", self.mod_dirs
-                        if self.mods:
-#                             print "######################################"
-#                             print self.materials
-#                              
-                            # Remove that when mod support is finished?
-                            self.materials.addJSONBlocksFromVersion(self.gameVersion, mods=mod_dirs)
+#                         if self.mods:
+# #                             print "######################################"
+# #                             print self.materials
+# #                              
+#                             # Remove that when mod support is finished?
+#                             self.materials.addJSONBlocksFromVersion(self.gameVersion, mods=mod_dirs, block_ids=block_ids)
                         end_time = time.time()
 #                         print "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 #                         print "Mods loading duration:", end_time - start_time

--- a/pymclevel/materials.py
+++ b/pymclevel/materials.py
@@ -730,6 +730,7 @@ archive is build like this:
 
 """
 
+# This class is not used, since MCMaterials one handles the mod loading.
 class ModMaterials(object):
 
     def __init__(self, parent_materials, mod_directory):
@@ -776,10 +777,10 @@ class ModMaterials(object):
 alphaMaterials = MCMaterials(defaultName="Future Block!")
 alphaMaterials.name = "Alpha"
 
-if os.path.exists('mods'):
-    for mod in next(os.walk('mods'))[1]: # TODO: Change this to data directories
-        if os.path.exists(os.path.join('mods', mod, 'blocks.json')):
-            ModMaterials(alphaMaterials, os.path.join('mods', mod))
+# if os.path.exists('mods'):
+#     for mod in next(os.walk('mods'))[1]: # TODO: Change this to data directories
+#         if os.path.exists(os.path.join('mods', mod, 'blocks.json')):
+#             ModMaterials(alphaMaterials, os.path.join('mods', mod))
 
 classicMaterials = MCMaterials(defaultName="Not present in Classic")
 classicMaterials.name = "Classic"

--- a/pymclevel/materials.py
+++ b/pymclevel/materials.py
@@ -422,7 +422,11 @@ class MCMaterials(object):
         if blockyaml:
             self.addJSONBlocks(blockyaml)
 
-    def addJSONBlocksFromVersion(self, game_version):
+    def addJSONBlocksFromVersion(self, game_version, mods={}):
+        """Adds block definitions for a specific game version.
+        :game_version: string: The game version to load the definitions for.
+        :mods: dict: Keys are mod names, values are path to the mod extracted data directory.
+            This directory shall contain files like built with modloader module."""
         # Load first the versionned stuff
         # Fallback to the old .json file
         log.debug("Loading block definitions from versionned file")
@@ -451,9 +455,30 @@ class MCMaterials(object):
             self.addJSONBlocksFromFile(f_name)
 #         print sorted(self.__dict__.keys())
         meth() # TODO: Remove this later, removing now causes things to break
-        build_api_material_map(self)
+#         build_api_material_map(self)
 #         print sorted(self.__dict__.keys())
 #         build_api_material_map()
+
+        # Load the data for the mods
+        for mod_name, mod_dir in mods.items():
+            log.info("Loading %s mod data from '%s'" % (mod_name, mod_dir))
+            print "Loading %s mod data from '%s'" % (mod_name, mod_dir)
+            for namespace in os.listdir(mod_dir):
+                print "namespace", namespace
+                namespace_path = os.path.join(mod_dir, namespace)
+                namespace_defs = {}
+                print "namespace_path", namespace_path
+                if namespace == "terrain.png":
+                    # TODO: Implement the texture file handling.
+                    pass
+                elif os.path.isdir(namespace_path):
+                    namespace_defs = id_definitions.ids_loader(game_version, namespace=namespace, json_dict=True, directory=namespace_path, update=True)
+#                     print namespace_defs
+#                     print id_definitions.MCEDIT_DEFS
+                if namespace_defs:
+                    self.addJSONBlocks(namespace_defs)
+        build_api_material_map(self)
+
 
     def addJSONBlocks(self, blockyaml):
         self.yamlDatas.append(blockyaml)
@@ -568,7 +593,7 @@ class MCMaterials(object):
 
         if attr_name not in self.__dict__:
             setattr(self, attr_name, block)
-            print attr_name
+#             print attr_name
 
         if kw.pop('invalid', 'false') == 'false':
             self.allBlocks.append(block)

--- a/pymclevel/materials.py
+++ b/pymclevel/materials.py
@@ -439,7 +439,7 @@ class MCMaterials(object):
         # Load first the versionned stuff
         # Fallback to the old .json file
         log.debug("Loading block definitions from versionned file")
-        print "#### Game Version: " + game_version
+        print "#### Game Version:", game_version
         game_version = game_version.replace('java ', '')
         blockyaml = id_definitions.ids_loader(game_version, json_dict=True)
         meth = None
@@ -462,21 +462,17 @@ class MCMaterials(object):
             self.addJSONBlocks(blockyaml)
         else:
             self.addJSONBlocksFromFile(f_name)
-#         print sorted(self.__dict__.keys())
         meth() # TODO: Remove this later, removing now causes things to break
-#         build_api_material_map(self)
-#         print sorted(self.__dict__.keys())
-#         build_api_material_map()
 
         # Load the data for the mods
         for mod_name, mod_dir in mods.items():
             log.info("Loading %s mod data from '%s'" % (mod_name, mod_dir))
             print "Loading %s mod data from '%s'" % (mod_name, mod_dir)
             for namespace in os.listdir(mod_dir):
-                print "namespace", namespace
+#                 print "namespace", namespace
                 namespace_path = os.path.join(mod_dir, namespace)
                 namespace_defs = {}
-                print "namespace_path", namespace_path
+#                 print "namespace_path", namespace_path
                 if namespace == "terrain.png":
                     # TODO: Implement the texture file handling.
                     pass

--- a/pymclevel/mclevel.py
+++ b/pymclevel/mclevel.py
@@ -193,7 +193,7 @@ class LoadingError(RuntimeError):
     pass
 
 
-def fromFile(filename, loadInfinite=True, readonly=False):
+def fromFile(filename, loadInfinite=True, readonly=False, check_only=False):
     ''' The preferred method for loading Minecraft levels of any type.
     pass False to loadInfinite if you'd rather not load infdev levels.
     '''
@@ -216,7 +216,7 @@ def fromFile(filename, loadInfinite=True, readonly=False):
     if MCInfdevOldLevel._isLevel(filename):
         log.info(u"Detected Infdev level.dat")
         if loadInfinite:
-            return MCInfdevOldLevel(filename=filename, readonly=readonly)
+            return MCInfdevOldLevel(filename=filename, readonly=readonly, check_only=check_only)
         else:
             raise ValueError("Asked to load {0} which is an infinite level, loadInfinite was False".format(
                 os.path.basename(filename)))

--- a/renderer.py
+++ b/renderer.py
@@ -1668,7 +1668,7 @@ class LowDetailBlockRenderer(BlockRenderer):
 
             flatcolors = level.materials.flatColors[blockTypes, ch.Data[blockIndices] & 0xf][:, numpy.newaxis, :]
             for mod_mats in mod_materials:
-                flatcolors += mod_mats.flatColors[blockTypes, ch.Data[blockIndices] & 0xf][:, numpy.newaxis, :]
+                flatcolors += mod_materials[mod_mats].flatColors[blockTypes, ch.Data[blockIndices] & 0xf][:, numpy.newaxis, :]
             x, z, y = blockIndices.nonzero()
 
             yield
@@ -1684,7 +1684,7 @@ class LowDetailBlockRenderer(BlockRenderer):
             overmask = overblocks > 0
             flatcolors[overmask] = level.materials.flatColors[:, 0][overblocks[overmask]][:, numpy.newaxis]
             for mod_mats in mod_materials:
-                flatcolors[overmask] += mod_mats.flatColors[:, 0][overblocks[overmask]][:, numpy.newaxis]
+                flatcolors[overmask] += mod_materials[mod_mats].flatColors[:, 0][overblocks[overmask]][:, numpy.newaxis]
 
             if self.detailLevel == 2:
                 heightfactor = (y / float(2.0 * ch.world.Height)) + 0.5
@@ -1718,7 +1718,7 @@ class LowDetailBlockRenderer(BlockRenderer):
             # color grass sides with dirt's color
             va1.view('uint8')[_RGBA][grassmask] = level.materials.flatColors[:, 0][[3]][:, numpy.newaxis]
             for mod_mats in mod_materials:
-                va1.view('uint8')[_RGBA][grassmask] += mod_mats.flatColors[:, 0][[3]][:, numpy.newaxis]
+                va1.view('uint8')[_RGBA][grassmask] += mod_materials[mod_mats].flatColors[:, 0][[3]][:, numpy.newaxis]
 
             va2 = numpy.array(va1)
             va2[_XYZ][:, (1, 2), 0] += step

--- a/renderer.py
+++ b/renderer.py
@@ -1664,11 +1664,11 @@ class LowDetailBlockRenderer(BlockRenderer):
         if nonAirBlocks.any():
             blockTypes = blocks[blockIndices]
 
-            mod_materials = getattr(level, "mod_materials", {})
+            mod_materials = getattr(level, "mod_materials", {}).values()
 
             flatcolors = level.materials.flatColors[blockTypes, ch.Data[blockIndices] & 0xf][:, numpy.newaxis, :]
             for mod_mats in mod_materials:
-                flatcolors += mod_materials[mod_mats].flatColors[blockTypes, ch.Data[blockIndices] & 0xf][:, numpy.newaxis, :]
+                flatcolors += mod_mats.flatColors[blockTypes, ch.Data[blockIndices] & 0xf][:, numpy.newaxis, :]
             x, z, y = blockIndices.nonzero()
 
             yield
@@ -1684,7 +1684,7 @@ class LowDetailBlockRenderer(BlockRenderer):
             overmask = overblocks > 0
             flatcolors[overmask] = level.materials.flatColors[:, 0][overblocks[overmask]][:, numpy.newaxis]
             for mod_mats in mod_materials:
-                flatcolors[overmask] += mod_materials[mod_mats].flatColors[:, 0][overblocks[overmask]][:, numpy.newaxis]
+                flatcolors[overmask] += mod_mats.flatColors[:, 0][overblocks[overmask]][:, numpy.newaxis]
 
             if self.detailLevel == 2:
                 heightfactor = (y / float(2.0 * ch.world.Height)) + 0.5
@@ -1718,7 +1718,7 @@ class LowDetailBlockRenderer(BlockRenderer):
             # color grass sides with dirt's color
             va1.view('uint8')[_RGBA][grassmask] = level.materials.flatColors[:, 0][[3]][:, numpy.newaxis]
             for mod_mats in mod_materials:
-                va1.view('uint8')[_RGBA][grassmask] += mod_materials[mod_mats].flatColors[:, 0][[3]][:, numpy.newaxis]
+                va1.view('uint8')[_RGBA][grassmask] += mod_mats.flatColors[:, 0][[3]][:, numpy.newaxis]
 
             va2 = numpy.array(va1)
             va2[_XYZ][:, (1, 2), 0] += step

--- a/utilities/gl_display_context.py
+++ b/utilities/gl_display_context.py
@@ -154,7 +154,7 @@ class GLDisplayContext(object):
 
         self.display = d
 
-#         self.loadTextures()
+        self.loadTextures()
 
     def getTerrainTexture(self, level):
         return self.terrainTextures.get(level.materials.name, self.terrainTextures["Alpha"])

--- a/utilities/gl_display_context.py
+++ b/utilities/gl_display_context.py
@@ -154,7 +154,7 @@ class GLDisplayContext(object):
 
         self.display = d
 
-        self.loadTextures()
+#         self.loadTextures()
 
     def getTerrainTexture(self, level):
         return self.terrainTextures.get(level.materials.name, self.terrainTextures["Alpha"])

--- a/utilities/thread_utils.py
+++ b/utilities/thread_utils.py
@@ -1,0 +1,63 @@
+# thread_utils.py
+#
+# D.C.-G. 2017
+#
+# Utilities to deal with threads.
+#
+import threading
+
+class ThreadRS(threading.Thread):
+    # This class comes from: http://stackoverflow.com/questions/6893968/how-to-get-the-return-value-from-a-thread-in-python
+    # And may have been tweaked ;)
+    """
+    This class uses a _return instance member to store the result of the underlying Thread object.
+    If 'callbacks' objects are send to the constructor, this '_result' object will be sent to all of them
+    at the end of the 'run' and 'join' method. The latest one also returns '_return' object.
+    """
+    def __init__(self, group=None, target=None, name=None, callbacks=[],
+                 args=(), kwargs={}, Verbose=None):
+        """
+        :callbacks: list: callable objects to send the thread result to.
+        For other arguments, see threading.Thread documentation.
+        """
+        self.target = target
+        self.callbacks = callbacks
+        threading.Thread.__init__(self, group, target, name, args, kwargs, Verbose)
+        self._return = None
+
+    def run(self):
+        if self._Thread__target is not None:
+            self._return = self._Thread__target(*self._Thread__args,
+                                                **self._Thread__kwargs)
+            for callback in self.callbacks:
+                callback(self._return)
+
+    def join(self):
+        try:
+            threading.Thread.join(self)
+        except Exception as e:
+            print e
+        for callback in self.callbacks:
+            callback(self._return)
+        return self._return
+
+    def __repr__(self, *args, **kwargs):
+        return '%s::%s' % (ThreadRS, self.target)
+
+
+def threadable(func):
+    def wrapper(*args, **kwargs):
+#         instance = None
+#         for arg in args:
+#             if isinstance(arg, klass):
+#                 instance = arg
+#                 break
+        # ! func MUST ALWAYS be an instance method !
+        # And the instace MUST ALWS have a 'targets' function list (or tuple) member.
+        instance = args[0]
+        with instance.cache_lock:
+            t = ThreadRS(target=func, args=args, kwargs=kwargs, callbacks=instance.targets)
+            t.daemon = True
+            t.start()
+            return t
+    return wrapper


### PR DESCRIPTION
* Mod handling optimization

  * Mods found in worlds are no more loaded at startup.  
    The mods are loaded only when the world is.  
    Added a 'check_only'keyword argument to MCInfdevOldLevel class  
    instanciation and to subsequent 'fromFile' and 'loadFile' methods.  

  * `mod_loader` module now handles a mod catalog (`mods/catalog`) which  
    contains data for already analyzed and extracted mod needed stuff.  
    This is used to avoid parsing and extrating .jar data every time a mod is  
    needed.

  * The json data produced by the mod loader is consumed by `id_fefinitions`.

  * `ModLoader` instances have a `texture` member which contains the loaded  
    PNG texture image. This member is `None` if no texture could be built  
    during mod loading.

  * Tried to load mods using threads to reduce loading time.  
    Don't work, the threaded solution being slower than the sequential one.  
    The code can be found in `pymclevel::MCInfdevOldLevel:loadLevelDat`.


* Refactor

  * Moved threading utilities from `player_cache.py` to its own sub module in  
    `utilities/thread_utils.py`.

  * Moved OpenGL code from `mceutils.py` to `gl_img_utils.py` to avoid cyclic  
    imports issues.


* Render tests

  Played around with the rendering code to make it show mod blocks.
  No success...

Changes since commit 3f7e50c7c28f7c129b2c07910cc3f94c89b60d7d

* Added missing 'thread_utils.py' file.
* Commented part which add the mod definitions to vanila ones because of data
  access issues during render.
* Implemented block numeric IDs corretion from 'level.dat' data.
* Reworked 'MCMaterials' class to be able to handle more than 16 sub-items in
  most of the members like 'names' and 'type'.
* Swithced to 'blockstates' .jar data instead of 'models' because 'blockstates'
  json data contains more information for data values, and files names are the
  ones in 'level.dat' mod datas.
* In the render, made 'BlockRenderer' instances (and children ones) accept a
  'mod_materials' key word argument for 'getBlocktypes' method and use it to
  try to retrieve needed data.
* Also made more generic functions to retrieve block types.
  Old code still there for ease of rollback if needed.

Mod blocks still can't be rendered...